### PR TITLE
add github.com/vladimirvivien/mesos-http/mesos/json to vendor

### DIFF
--- a/vendor/github.com/vladimirvivien/mesos-http/mesos/json/LICENSE
+++ b/vendor/github.com/vladimirvivien/mesos-http/mesos/json/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Vladimir Vivien
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/vladimirvivien/mesos-http/mesos/json/call.go
+++ b/vendor/github.com/vladimirvivien/mesos-http/mesos/json/call.go
@@ -1,0 +1,18 @@
+package json
+
+type Call struct {
+	Type      string     `json:"type"`
+	Subscribe *Subscribe `json:"subscribe"`
+}
+type Subscribe struct {
+	FrameworkInfo *FrameworkInfo `json:"framework_info"`
+}
+type FrameworkInfo struct {
+	User         string `json:"user"`
+	Name         string `json:"name"`
+	HostName     string `json:"hostname"`
+	*FrameworkID `json:"framework_id"`
+}
+type FrameworkID struct {
+	Value string `json:"value"`
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -96,6 +96,15 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/vladimirvivien/mesos-http/mesos/json",
+			"repository": "https://github.com/vladimirvivien/mesos-http",
+			"vcs": "git",
+			"revision": "5e20931482e8f5051ce555266fb4ed317f68cd94",
+			"branch": "master",
+			"path": "/mesos/json",
+			"notests": true
+		},
+		{
 			"importpath": "gopkg.in/mgo.v2/bson",
 			"repository": "https://gopkg.in/mgo.v2",
 			"vcs": "git",


### PR DESCRIPTION
fixed
```
scheduler/client/http.go:12:2: cannot find package "github.com/vladimirvivien/mesos-http/mesos/json" in any of:
        /Users/yaoyun/go/src/github.com/Dataman-Cloud/swan/vendor/github.com/vladimirvivien/mesos-http/mesos/json (vendor tree)
        /usr/local/Cellar/go/1.6.2/libexec/src/github.com/vladimirvivien/mesos-http/mesos/json (from $GOROOT)
        /Users/yaoyun/go/src/github.com/vladimirvivien/mesos-http/mesos/json (from $GOPATH)
```