### PR TITLE
add signal trap for doing clean up work

### DIFF
--- a/src/manager/apiserver/server.go
+++ b/src/manager/apiserver/server.go
@@ -79,6 +79,7 @@ func (s *ApiServer) ListenAndServe() error {
 			Addr:    s.sock,
 			Handler: s.createMux(),
 		}
+		logrus.Infof("unix://%s", s.sock)
 		ln, err := net.ListenUnix("unix", &net.UnixAddr{
 			Name: s.sock,
 			Net:  "unix",

--- a/src/util/config.go
+++ b/src/util/config.go
@@ -49,8 +49,8 @@ type DNS struct {
 }
 
 type HttpListener struct {
-	TCPAddr  string `json:"tcp-addr"`
-	UnixAddr string `json:"unix-addr"`
+	TCPAddr  string `json:"addr"`
+	UnixAddr string `json:"sock"`
 }
 
 type IPAM struct {
@@ -70,7 +70,7 @@ func NewConfig(c *cli.Context) (SwanConfig, error) {
 		Standalone: c.Bool("standablone"),
 		HttpListener: HttpListener{
 			TCPAddr:  c.String("addr"),
-			UnixAddr: c.String("unix_addr"),
+			UnixAddr: c.String("sock"),
 		},
 
 		Scheduler: Scheduler{


### PR DESCRIPTION
添加了信号捕捉的函数，在程序退出时删除监听的sock文件，要不然使用旧的socket文件swancfg那边会出错。这个实现不是很好，但正常工作是没有问题的。