### PR TITLE
PoC: Port go-restful into Swan

### DIFF
--- a/src/manager/framework/framework.go
+++ b/src/manager/framework/framework.go
@@ -14,6 +14,7 @@ import (
 type Framework struct {
 	Scheduler *scheduler.Scheduler
 	HttpApi   *api.Api
+	RestApi   *api.AppService
 
 	StopC chan struct{}
 }
@@ -24,6 +25,7 @@ func New(config util.SwanConfig) (*Framework, error) {
 	}
 	f.Scheduler = scheduler.NewScheduler(config)
 	f.HttpApi = api.NewApi(f.Scheduler)
+	f.RestApi = api.NewAppService(f.Scheduler)
 
 	return f, nil
 }

--- a/src/manager/framework/scheduler/scheduler_api.go
+++ b/src/manager/framework/scheduler/scheduler_api.go
@@ -7,15 +7,15 @@ import (
 	"github.com/Dataman-Cloud/swan/src/types"
 )
 
-func (scheduler *Scheduler) CreateApp(version *types.Version) error {
+func (scheduler *Scheduler) CreateApp(version *types.Version) (*state.App, error) {
 	_, appExists := scheduler.Apps[version.AppId]
 	if appExists {
-		return errors.New("app already exists")
+		return nil, errors.New("app already exists")
 	}
 
 	app, err := state.NewApp(version, scheduler.Allocator, scheduler.MesosConnector)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	scheduler.appLock.Lock()
@@ -23,7 +23,7 @@ func (scheduler *Scheduler) CreateApp(version *types.Version) error {
 
 	scheduler.Apps[version.AppId] = app
 
-	return nil
+	return app, nil
 }
 
 func (scheduler *Scheduler) InspectApp(appId string) (*state.App, error) {

--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -146,6 +146,8 @@ func (manager *Manager) handleLeadershipEvents(ctx context.Context, leadershipCh
 				} else {
 					frameworkCtx, _ := context.WithCancel(ctx)
 					manager.framework.Start(frameworkCtx)
+					// TODO(xychu): will reconsider when and where to start the global api server
+					manager.framework.RestApi.Start()
 				}
 
 			} else if newState == raft.IsFollower {

--- a/src/manager/sched/api/application.go
+++ b/src/manager/sched/api/application.go
@@ -79,7 +79,15 @@ func (r *Router) BuildApplication(w http.ResponseWriter, req *http.Request) erro
 		return err
 	}
 
-	return nil
+	// return nil
+	// return created app
+	app, err = r.backend.FetchApplication(version.AppId)
+	if err != nil {
+		logrus.Errorf("Fetch application %s failed: %s", version.AppId, err.Error())
+	}
+
+	return json.NewEncoder(w).Encode(app)
+
 }
 
 // ListApplication is used to list all applications.

--- a/vendor/github.com/emicklei/go-restful/LICENSE
+++ b/vendor/github.com/emicklei/go-restful/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2012,2013 Ernest Micklei
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/emicklei/go-restful/compress.go
+++ b/vendor/github.com/emicklei/go-restful/compress.go
@@ -1,0 +1,123 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bufio"
+	"compress/gzip"
+	"compress/zlib"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// OBSOLETE : use restful.DefaultContainer.EnableContentEncoding(true) to change this setting.
+var EnableContentEncoding = false
+
+// CompressingResponseWriter is a http.ResponseWriter that can perform content encoding (gzip and zlib)
+type CompressingResponseWriter struct {
+	writer     http.ResponseWriter
+	compressor io.WriteCloser
+	encoding   string
+}
+
+// Header is part of http.ResponseWriter interface
+func (c *CompressingResponseWriter) Header() http.Header {
+	return c.writer.Header()
+}
+
+// WriteHeader is part of http.ResponseWriter interface
+func (c *CompressingResponseWriter) WriteHeader(status int) {
+	c.writer.WriteHeader(status)
+}
+
+// Write is part of http.ResponseWriter interface
+// It is passed through the compressor
+func (c *CompressingResponseWriter) Write(bytes []byte) (int, error) {
+	if c.isCompressorClosed() {
+		return -1, errors.New("Compressing error: tried to write data using closed compressor")
+	}
+	return c.compressor.Write(bytes)
+}
+
+// CloseNotify is part of http.CloseNotifier interface
+func (c *CompressingResponseWriter) CloseNotify() <-chan bool {
+	return c.writer.(http.CloseNotifier).CloseNotify()
+}
+
+// Close the underlying compressor
+func (c *CompressingResponseWriter) Close() error {
+	if c.isCompressorClosed() {
+		return errors.New("Compressing error: tried to close already closed compressor")
+	}
+
+	c.compressor.Close()
+	if ENCODING_GZIP == c.encoding {
+		currentCompressorProvider.ReleaseGzipWriter(c.compressor.(*gzip.Writer))
+	}
+	if ENCODING_DEFLATE == c.encoding {
+		currentCompressorProvider.ReleaseZlibWriter(c.compressor.(*zlib.Writer))
+	}
+	// gc hint needed?
+	c.compressor = nil
+	return nil
+}
+
+func (c *CompressingResponseWriter) isCompressorClosed() bool {
+	return nil == c.compressor
+}
+
+// Hijack implements the Hijacker interface
+// This is especially useful when combining Container.EnabledContentEncoding
+// in combination with websockets (for instance gorilla/websocket)
+func (c *CompressingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := c.writer.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("ResponseWriter doesn't support Hijacker interface")
+	}
+	return hijacker.Hijack()
+}
+
+// WantsCompressedResponse reads the Accept-Encoding header to see if and which encoding is requested.
+func wantsCompressedResponse(httpRequest *http.Request) (bool, string) {
+	header := httpRequest.Header.Get(HEADER_AcceptEncoding)
+	gi := strings.Index(header, ENCODING_GZIP)
+	zi := strings.Index(header, ENCODING_DEFLATE)
+	// use in order of appearance
+	if gi == -1 {
+		return zi != -1, ENCODING_DEFLATE
+	} else if zi == -1 {
+		return gi != -1, ENCODING_GZIP
+	} else {
+		if gi < zi {
+			return true, ENCODING_GZIP
+		}
+		return true, ENCODING_DEFLATE
+	}
+}
+
+// NewCompressingResponseWriter create a CompressingResponseWriter for a known encoding = {gzip,deflate}
+func NewCompressingResponseWriter(httpWriter http.ResponseWriter, encoding string) (*CompressingResponseWriter, error) {
+	httpWriter.Header().Set(HEADER_ContentEncoding, encoding)
+	c := new(CompressingResponseWriter)
+	c.writer = httpWriter
+	var err error
+	if ENCODING_GZIP == encoding {
+		w := currentCompressorProvider.AcquireGzipWriter()
+		w.Reset(httpWriter)
+		c.compressor = w
+		c.encoding = ENCODING_GZIP
+	} else if ENCODING_DEFLATE == encoding {
+		w := currentCompressorProvider.AcquireZlibWriter()
+		w.Reset(httpWriter)
+		c.compressor = w
+		c.encoding = ENCODING_DEFLATE
+	} else {
+		return nil, errors.New("Unknown encoding:" + encoding)
+	}
+	return c, err
+}

--- a/vendor/github.com/emicklei/go-restful/compressor_cache.go
+++ b/vendor/github.com/emicklei/go-restful/compressor_cache.go
@@ -1,0 +1,103 @@
+package restful
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"compress/gzip"
+	"compress/zlib"
+)
+
+// BoundedCachedCompressors is a CompressorProvider that uses a cache with a fixed amount
+// of writers and readers (resources).
+// If a new resource is acquired and all are in use, it will return a new unmanaged resource.
+type BoundedCachedCompressors struct {
+	gzipWriters     chan *gzip.Writer
+	gzipReaders     chan *gzip.Reader
+	zlibWriters     chan *zlib.Writer
+	writersCapacity int
+	readersCapacity int
+}
+
+// NewBoundedCachedCompressors returns a new, with filled cache,  BoundedCachedCompressors.
+func NewBoundedCachedCompressors(writersCapacity, readersCapacity int) *BoundedCachedCompressors {
+	b := &BoundedCachedCompressors{
+		gzipWriters:     make(chan *gzip.Writer, writersCapacity),
+		gzipReaders:     make(chan *gzip.Reader, readersCapacity),
+		zlibWriters:     make(chan *zlib.Writer, writersCapacity),
+		writersCapacity: writersCapacity,
+		readersCapacity: readersCapacity,
+	}
+	for ix := 0; ix < writersCapacity; ix++ {
+		b.gzipWriters <- newGzipWriter()
+		b.zlibWriters <- newZlibWriter()
+	}
+	for ix := 0; ix < readersCapacity; ix++ {
+		b.gzipReaders <- newGzipReader()
+	}
+	return b
+}
+
+// AcquireGzipWriter returns an resettable *gzip.Writer. Needs to be released.
+func (b *BoundedCachedCompressors) AcquireGzipWriter() *gzip.Writer {
+	var writer *gzip.Writer
+	select {
+	case writer, _ = <-b.gzipWriters:
+	default:
+		// return a new unmanaged one
+		writer = newGzipWriter()
+	}
+	return writer
+}
+
+// ReleaseGzipWriter accepts a writer (does not have to be one that was cached)
+// only when the cache has room for it. It will ignore it otherwise.
+func (b *BoundedCachedCompressors) ReleaseGzipWriter(w *gzip.Writer) {
+	// forget the unmanaged ones
+	if len(b.gzipWriters) < b.writersCapacity {
+		b.gzipWriters <- w
+	}
+}
+
+// AcquireGzipReader returns a *gzip.Reader. Needs to be released.
+func (b *BoundedCachedCompressors) AcquireGzipReader() *gzip.Reader {
+	var reader *gzip.Reader
+	select {
+	case reader, _ = <-b.gzipReaders:
+	default:
+		// return a new unmanaged one
+		reader = newGzipReader()
+	}
+	return reader
+}
+
+// ReleaseGzipReader accepts a reader (does not have to be one that was cached)
+// only when the cache has room for it. It will ignore it otherwise.
+func (b *BoundedCachedCompressors) ReleaseGzipReader(r *gzip.Reader) {
+	// forget the unmanaged ones
+	if len(b.gzipReaders) < b.readersCapacity {
+		b.gzipReaders <- r
+	}
+}
+
+// AcquireZlibWriter returns an resettable *zlib.Writer. Needs to be released.
+func (b *BoundedCachedCompressors) AcquireZlibWriter() *zlib.Writer {
+	var writer *zlib.Writer
+	select {
+	case writer, _ = <-b.zlibWriters:
+	default:
+		// return a new unmanaged one
+		writer = newZlibWriter()
+	}
+	return writer
+}
+
+// ReleaseZlibWriter accepts a writer (does not have to be one that was cached)
+// only when the cache has room for it. It will ignore it otherwise.
+func (b *BoundedCachedCompressors) ReleaseZlibWriter(w *zlib.Writer) {
+	// forget the unmanaged ones
+	if len(b.zlibWriters) < b.writersCapacity {
+		b.zlibWriters <- w
+	}
+}

--- a/vendor/github.com/emicklei/go-restful/compressor_pools.go
+++ b/vendor/github.com/emicklei/go-restful/compressor_pools.go
@@ -1,0 +1,91 @@
+package restful
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
+	"sync"
+)
+
+// SyncPoolCompessors is a CompressorProvider that use the standard sync.Pool.
+type SyncPoolCompessors struct {
+	GzipWriterPool *sync.Pool
+	GzipReaderPool *sync.Pool
+	ZlibWriterPool *sync.Pool
+}
+
+// NewSyncPoolCompessors returns a new ("empty") SyncPoolCompessors.
+func NewSyncPoolCompessors() *SyncPoolCompessors {
+	return &SyncPoolCompessors{
+		GzipWriterPool: &sync.Pool{
+			New: func() interface{} { return newGzipWriter() },
+		},
+		GzipReaderPool: &sync.Pool{
+			New: func() interface{} { return newGzipReader() },
+		},
+		ZlibWriterPool: &sync.Pool{
+			New: func() interface{} { return newZlibWriter() },
+		},
+	}
+}
+
+func (s *SyncPoolCompessors) AcquireGzipWriter() *gzip.Writer {
+	return s.GzipWriterPool.Get().(*gzip.Writer)
+}
+
+func (s *SyncPoolCompessors) ReleaseGzipWriter(w *gzip.Writer) {
+	s.GzipWriterPool.Put(w)
+}
+
+func (s *SyncPoolCompessors) AcquireGzipReader() *gzip.Reader {
+	return s.GzipReaderPool.Get().(*gzip.Reader)
+}
+
+func (s *SyncPoolCompessors) ReleaseGzipReader(r *gzip.Reader) {
+	s.GzipReaderPool.Put(r)
+}
+
+func (s *SyncPoolCompessors) AcquireZlibWriter() *zlib.Writer {
+	return s.ZlibWriterPool.Get().(*zlib.Writer)
+}
+
+func (s *SyncPoolCompessors) ReleaseZlibWriter(w *zlib.Writer) {
+	s.ZlibWriterPool.Put(w)
+}
+
+func newGzipWriter() *gzip.Writer {
+	// create with an empty bytes writer; it will be replaced before using the gzipWriter
+	writer, err := gzip.NewWriterLevel(new(bytes.Buffer), gzip.BestSpeed)
+	if err != nil {
+		panic(err.Error())
+	}
+	return writer
+}
+
+func newGzipReader() *gzip.Reader {
+	// create with an empty reader (but with GZIP header); it will be replaced before using the gzipReader
+	// we can safely use currentCompressProvider because it is set on package initialization.
+	w := currentCompressorProvider.AcquireGzipWriter()
+	defer currentCompressorProvider.ReleaseGzipWriter(w)
+	b := new(bytes.Buffer)
+	w.Reset(b)
+	w.Flush()
+	w.Close()
+	reader, err := gzip.NewReader(bytes.NewReader(b.Bytes()))
+	if err != nil {
+		panic(err.Error())
+	}
+	return reader
+}
+
+func newZlibWriter() *zlib.Writer {
+	writer, err := zlib.NewWriterLevel(new(bytes.Buffer), gzip.BestSpeed)
+	if err != nil {
+		panic(err.Error())
+	}
+	return writer
+}

--- a/vendor/github.com/emicklei/go-restful/compressors.go
+++ b/vendor/github.com/emicklei/go-restful/compressors.go
@@ -1,0 +1,53 @@
+package restful
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"compress/gzip"
+	"compress/zlib"
+)
+
+type CompressorProvider interface {
+	// Returns a *gzip.Writer which needs to be released later.
+	// Before using it, call Reset().
+	AcquireGzipWriter() *gzip.Writer
+
+	// Releases an aqcuired *gzip.Writer.
+	ReleaseGzipWriter(w *gzip.Writer)
+
+	// Returns a *gzip.Reader which needs to be released later.
+	AcquireGzipReader() *gzip.Reader
+
+	// Releases an aqcuired *gzip.Reader.
+	ReleaseGzipReader(w *gzip.Reader)
+
+	// Returns a *zlib.Writer which needs to be released later.
+	// Before using it, call Reset().
+	AcquireZlibWriter() *zlib.Writer
+
+	// Releases an aqcuired *zlib.Writer.
+	ReleaseZlibWriter(w *zlib.Writer)
+}
+
+// DefaultCompressorProvider is the actual provider of compressors (zlib or gzip).
+var currentCompressorProvider CompressorProvider
+
+func init() {
+	currentCompressorProvider = NewSyncPoolCompessors()
+}
+
+// CurrentCompressorProvider returns the current CompressorProvider.
+// It is initialized using a SyncPoolCompessors.
+func CurrentCompressorProvider() CompressorProvider {
+	return currentCompressorProvider
+}
+
+// CompressorProvider sets the actual provider of compressors (zlib or gzip).
+func SetCompressorProvider(p CompressorProvider) {
+	if p == nil {
+		panic("cannot set compressor provider to nil")
+	}
+	currentCompressorProvider = p
+}

--- a/vendor/github.com/emicklei/go-restful/constants.go
+++ b/vendor/github.com/emicklei/go-restful/constants.go
@@ -1,0 +1,30 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+const (
+	MIME_XML   = "application/xml"          // Accept or Content-Type used in Consumes() and/or Produces()
+	MIME_JSON  = "application/json"         // Accept or Content-Type used in Consumes() and/or Produces()
+	MIME_OCTET = "application/octet-stream" // If Content-Type is not present in request, use the default
+
+	HEADER_Allow                         = "Allow"
+	HEADER_Accept                        = "Accept"
+	HEADER_Origin                        = "Origin"
+	HEADER_ContentType                   = "Content-Type"
+	HEADER_LastModified                  = "Last-Modified"
+	HEADER_AcceptEncoding                = "Accept-Encoding"
+	HEADER_ContentEncoding               = "Content-Encoding"
+	HEADER_AccessControlExposeHeaders    = "Access-Control-Expose-Headers"
+	HEADER_AccessControlRequestMethod    = "Access-Control-Request-Method"
+	HEADER_AccessControlRequestHeaders   = "Access-Control-Request-Headers"
+	HEADER_AccessControlAllowMethods     = "Access-Control-Allow-Methods"
+	HEADER_AccessControlAllowOrigin      = "Access-Control-Allow-Origin"
+	HEADER_AccessControlAllowCredentials = "Access-Control-Allow-Credentials"
+	HEADER_AccessControlAllowHeaders     = "Access-Control-Allow-Headers"
+	HEADER_AccessControlMaxAge           = "Access-Control-Max-Age"
+
+	ENCODING_GZIP    = "gzip"
+	ENCODING_DEFLATE = "deflate"
+)

--- a/vendor/github.com/emicklei/go-restful/container.go
+++ b/vendor/github.com/emicklei/go-restful/container.go
@@ -1,0 +1,361 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/emicklei/go-restful/log"
+)
+
+// Container holds a collection of WebServices and a http.ServeMux to dispatch http requests.
+// The requests are further dispatched to routes of WebServices using a RouteSelector
+type Container struct {
+	webServicesLock        sync.RWMutex
+	webServices            []*WebService
+	ServeMux               *http.ServeMux
+	isRegisteredOnRoot     bool
+	containerFilters       []FilterFunction
+	doNotRecover           bool // default is true
+	recoverHandleFunc      RecoverHandleFunction
+	serviceErrorHandleFunc ServiceErrorHandleFunction
+	router                 RouteSelector // default is a CurlyRouter (RouterJSR311 is a slower alternative)
+	contentEncodingEnabled bool          // default is false
+}
+
+// NewContainer creates a new Container using a new ServeMux and default router (RouterJSR311)
+func NewContainer() *Container {
+	return &Container{
+		webServices:            []*WebService{},
+		ServeMux:               http.NewServeMux(),
+		isRegisteredOnRoot:     false,
+		containerFilters:       []FilterFunction{},
+		doNotRecover:           true,
+		recoverHandleFunc:      logStackOnRecover,
+		serviceErrorHandleFunc: writeServiceError,
+		router:                 CurlyRouter{},
+		contentEncodingEnabled: false}
+}
+
+// RecoverHandleFunction declares functions that can be used to handle a panic situation.
+// The first argument is what recover() returns. The second must be used to communicate an error response.
+type RecoverHandleFunction func(interface{}, http.ResponseWriter)
+
+// RecoverHandler changes the default function (logStackOnRecover) to be called
+// when a panic is detected. DoNotRecover must be have its default value (=false).
+func (c *Container) RecoverHandler(handler RecoverHandleFunction) {
+	c.recoverHandleFunc = handler
+}
+
+// ServiceErrorHandleFunction declares functions that can be used to handle a service error situation.
+// The first argument is the service error, the second is the request that resulted in the error and
+// the third must be used to communicate an error response.
+type ServiceErrorHandleFunction func(ServiceError, *Request, *Response)
+
+// ServiceErrorHandler changes the default function (writeServiceError) to be called
+// when a ServiceError is detected.
+func (c *Container) ServiceErrorHandler(handler ServiceErrorHandleFunction) {
+	c.serviceErrorHandleFunc = handler
+}
+
+// DoNotRecover controls whether panics will be caught to return HTTP 500.
+// If set to true, Route functions are responsible for handling any error situation.
+// Default value is true.
+func (c *Container) DoNotRecover(doNot bool) {
+	c.doNotRecover = doNot
+}
+
+// Router changes the default Router (currently RouterJSR311)
+func (c *Container) Router(aRouter RouteSelector) {
+	c.router = aRouter
+}
+
+// EnableContentEncoding (default=false) allows for GZIP or DEFLATE encoding of responses.
+func (c *Container) EnableContentEncoding(enabled bool) {
+	c.contentEncodingEnabled = enabled
+}
+
+// Add a WebService to the Container. It will detect duplicate root paths and exit in that case.
+func (c *Container) Add(service *WebService) *Container {
+	c.webServicesLock.Lock()
+	defer c.webServicesLock.Unlock()
+
+	// if rootPath was not set then lazy initialize it
+	if len(service.rootPath) == 0 {
+		service.Path("/")
+	}
+
+	// cannot have duplicate root paths
+	for _, each := range c.webServices {
+		if each.RootPath() == service.RootPath() {
+			log.Printf("[restful] WebService with duplicate root path detected:['%v']", each)
+			os.Exit(1)
+		}
+	}
+
+	// If not registered on root then add specific mapping
+	if !c.isRegisteredOnRoot {
+		c.isRegisteredOnRoot = c.addHandler(service, c.ServeMux)
+	}
+	c.webServices = append(c.webServices, service)
+	return c
+}
+
+// addHandler may set a new HandleFunc for the serveMux
+// this function must run inside the critical region protected by the webServicesLock.
+// returns true if the function was registered on root ("/")
+func (c *Container) addHandler(service *WebService, serveMux *http.ServeMux) bool {
+	pattern := fixedPrefixPath(service.RootPath())
+	// check if root path registration is needed
+	if "/" == pattern || "" == pattern {
+		serveMux.HandleFunc("/", c.dispatch)
+		return true
+	}
+	// detect if registration already exists
+	alreadyMapped := false
+	for _, each := range c.webServices {
+		if each.RootPath() == service.RootPath() {
+			alreadyMapped = true
+			break
+		}
+	}
+	if !alreadyMapped {
+		serveMux.HandleFunc(pattern, c.dispatch)
+		if !strings.HasSuffix(pattern, "/") {
+			serveMux.HandleFunc(pattern+"/", c.dispatch)
+		}
+	}
+	return false
+}
+
+func (c *Container) Remove(ws *WebService) error {
+	if c.ServeMux == http.DefaultServeMux {
+		errMsg := fmt.Sprintf("[restful] cannot remove a WebService from a Container using the DefaultServeMux: ['%v']", ws)
+		log.Printf(errMsg)
+		return errors.New(errMsg)
+	}
+	c.webServicesLock.Lock()
+	defer c.webServicesLock.Unlock()
+	// build a new ServeMux and re-register all WebServices
+	newServeMux := http.NewServeMux()
+	newServices := []*WebService{}
+	newIsRegisteredOnRoot := false
+	for _, each := range c.webServices {
+		if each.rootPath != ws.rootPath {
+			// If not registered on root then add specific mapping
+			if !newIsRegisteredOnRoot {
+				newIsRegisteredOnRoot = c.addHandler(each, newServeMux)
+			}
+			newServices = append(newServices, each)
+		}
+	}
+	c.webServices, c.ServeMux, c.isRegisteredOnRoot = newServices, newServeMux, newIsRegisteredOnRoot
+	return nil
+}
+
+// logStackOnRecover is the default RecoverHandleFunction and is called
+// when DoNotRecover is false and the recoverHandleFunc is not set for the container.
+// Default implementation logs the stacktrace and writes the stacktrace on the response.
+// This may be a security issue as it exposes sourcecode information.
+func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) {
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("[restful] recover from panic situation: - %v\r\n", panicReason))
+	for i := 2; ; i += 1 {
+		_, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		buffer.WriteString(fmt.Sprintf("    %s:%d\r\n", file, line))
+	}
+	log.Print(buffer.String())
+	httpWriter.WriteHeader(http.StatusInternalServerError)
+	httpWriter.Write(buffer.Bytes())
+}
+
+// writeServiceError is the default ServiceErrorHandleFunction and is called
+// when a ServiceError is returned during route selection. Default implementation
+// calls resp.WriteErrorString(err.Code, err.Message)
+func writeServiceError(err ServiceError, req *Request, resp *Response) {
+	resp.WriteErrorString(err.Code, err.Message)
+}
+
+// Dispatch the incoming Http Request to a matching WebService.
+func (c *Container) dispatch(httpWriter http.ResponseWriter, httpRequest *http.Request) {
+	writer := httpWriter
+
+	// CompressingResponseWriter should be closed after all operations are done
+	defer func() {
+		if compressWriter, ok := writer.(*CompressingResponseWriter); ok {
+			compressWriter.Close()
+		}
+	}()
+
+	// Instal panic recovery unless told otherwise
+	if !c.doNotRecover { // catch all for 500 response
+		defer func() {
+			if r := recover(); r != nil {
+				c.recoverHandleFunc(r, writer)
+				return
+			}
+		}()
+	}
+	// Install closing the request body (if any)
+	defer func() {
+		if nil != httpRequest.Body {
+			httpRequest.Body.Close()
+		}
+	}()
+
+	// Detect if compression is needed
+	// assume without compression, test for override
+	if c.contentEncodingEnabled {
+		doCompress, encoding := wantsCompressedResponse(httpRequest)
+		if doCompress {
+			var err error
+			writer, err = NewCompressingResponseWriter(httpWriter, encoding)
+			if err != nil {
+				log.Print("[restful] unable to install compressor: ", err)
+				httpWriter.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+	}
+	// Find best match Route ; err is non nil if no match was found
+	var webService *WebService
+	var route *Route
+	var err error
+	func() {
+		c.webServicesLock.RLock()
+		defer c.webServicesLock.RUnlock()
+		webService, route, err = c.router.SelectRoute(
+			c.webServices,
+			httpRequest)
+	}()
+	if err != nil {
+		// a non-200 response has already been written
+		// run container filters anyway ; they should not touch the response...
+		chain := FilterChain{Filters: c.containerFilters, Target: func(req *Request, resp *Response) {
+			switch err.(type) {
+			case ServiceError:
+				ser := err.(ServiceError)
+				c.serviceErrorHandleFunc(ser, req, resp)
+			}
+			// TODO
+		}}
+		chain.ProcessFilter(NewRequest(httpRequest), NewResponse(writer))
+		return
+	}
+	wrappedRequest, wrappedResponse := route.wrapRequestResponse(writer, httpRequest)
+	// pass through filters (if any)
+	if len(c.containerFilters)+len(webService.filters)+len(route.Filters) > 0 {
+		// compose filter chain
+		allFilters := []FilterFunction{}
+		allFilters = append(allFilters, c.containerFilters...)
+		allFilters = append(allFilters, webService.filters...)
+		allFilters = append(allFilters, route.Filters...)
+		chain := FilterChain{Filters: allFilters, Target: func(req *Request, resp *Response) {
+			// handle request by route after passing all filters
+			route.Function(wrappedRequest, wrappedResponse)
+		}}
+		chain.ProcessFilter(wrappedRequest, wrappedResponse)
+	} else {
+		// no filters, handle request by route
+		route.Function(wrappedRequest, wrappedResponse)
+	}
+}
+
+// fixedPrefixPath returns the fixed part of the partspec ; it may include template vars {}
+func fixedPrefixPath(pathspec string) string {
+	varBegin := strings.Index(pathspec, "{")
+	if -1 == varBegin {
+		return pathspec
+	}
+	return pathspec[:varBegin]
+}
+
+// ServeHTTP implements net/http.Handler therefore a Container can be a Handler in a http.Server
+func (c *Container) ServeHTTP(httpwriter http.ResponseWriter, httpRequest *http.Request) {
+	c.ServeMux.ServeHTTP(httpwriter, httpRequest)
+}
+
+// Handle registers the handler for the given pattern. If a handler already exists for pattern, Handle panics.
+func (c *Container) Handle(pattern string, handler http.Handler) {
+	c.ServeMux.Handle(pattern, handler)
+}
+
+// HandleWithFilter registers the handler for the given pattern.
+// Container's filter chain is applied for handler.
+// If a handler already exists for pattern, HandleWithFilter panics.
+func (c *Container) HandleWithFilter(pattern string, handler http.Handler) {
+	f := func(httpResponse http.ResponseWriter, httpRequest *http.Request) {
+		if len(c.containerFilters) == 0 {
+			handler.ServeHTTP(httpResponse, httpRequest)
+			return
+		}
+
+		chain := FilterChain{Filters: c.containerFilters, Target: func(req *Request, resp *Response) {
+			handler.ServeHTTP(httpResponse, httpRequest)
+		}}
+		chain.ProcessFilter(NewRequest(httpRequest), NewResponse(httpResponse))
+	}
+
+	c.Handle(pattern, http.HandlerFunc(f))
+}
+
+// Filter appends a container FilterFunction. These are called before dispatching
+// a http.Request to a WebService from the container
+func (c *Container) Filter(filter FilterFunction) {
+	c.containerFilters = append(c.containerFilters, filter)
+}
+
+// RegisteredWebServices returns the collections of added WebServices
+func (c *Container) RegisteredWebServices() []*WebService {
+	c.webServicesLock.RLock()
+	defer c.webServicesLock.RUnlock()
+	result := make([]*WebService, len(c.webServices))
+	for ix := range c.webServices {
+		result[ix] = c.webServices[ix]
+	}
+	return result
+}
+
+// computeAllowedMethods returns a list of HTTP methods that are valid for a Request
+func (c *Container) computeAllowedMethods(req *Request) []string {
+	// Go through all RegisteredWebServices() and all its Routes to collect the options
+	methods := []string{}
+	requestPath := req.Request.URL.Path
+	for _, ws := range c.RegisteredWebServices() {
+		matches := ws.pathExpr.Matcher.FindStringSubmatch(requestPath)
+		if matches != nil {
+			finalMatch := matches[len(matches)-1]
+			for _, rt := range ws.Routes() {
+				matches := rt.pathExpr.Matcher.FindStringSubmatch(finalMatch)
+				if matches != nil {
+					lastMatch := matches[len(matches)-1]
+					if lastMatch == "" || lastMatch == "/" { // do not include if value is neither empty nor ‘/’.
+						methods = append(methods, rt.Method)
+					}
+				}
+			}
+		}
+	}
+	// methods = append(methods, "OPTIONS")  not sure about this
+	return methods
+}
+
+// newBasicRequestResponse creates a pair of Request,Response from its http versions.
+// It is basic because no parameter or (produces) content-type information is given.
+func newBasicRequestResponse(httpWriter http.ResponseWriter, httpRequest *http.Request) (*Request, *Response) {
+	resp := NewResponse(httpWriter)
+	resp.requestAccept = httpRequest.Header.Get(HEADER_Accept)
+	return NewRequest(httpRequest), resp
+}

--- a/vendor/github.com/emicklei/go-restful/cors_filter.go
+++ b/vendor/github.com/emicklei/go-restful/cors_filter.go
@@ -1,0 +1,202 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// CrossOriginResourceSharing is used to create a Container Filter that implements CORS.
+// Cross-origin resource sharing (CORS) is a mechanism that allows JavaScript on a web page
+// to make XMLHttpRequests to another domain, not the domain the JavaScript originated from.
+//
+// http://en.wikipedia.org/wiki/Cross-origin_resource_sharing
+// http://enable-cors.org/server.html
+// http://www.html5rocks.com/en/tutorials/cors/#toc-handling-a-not-so-simple-request
+type CrossOriginResourceSharing struct {
+	ExposeHeaders  []string // list of Header names
+	AllowedHeaders []string // list of Header names
+	AllowedDomains []string // list of allowed values for Http Origin. An allowed value can be a regular expression to support subdomain matching. If empty all are allowed.
+	AllowedMethods []string
+	MaxAge         int // number of seconds before requiring new Options request
+	CookiesAllowed bool
+	Container      *Container
+
+	allowedOriginPatterns []*regexp.Regexp // internal field for origin regexp check.
+}
+
+// Filter is a filter function that implements the CORS flow as documented on http://enable-cors.org/server.html
+// and http://www.html5rocks.com/static/images/cors_server_flowchart.png
+func (c CrossOriginResourceSharing) Filter(req *Request, resp *Response, chain *FilterChain) {
+	origin := req.Request.Header.Get(HEADER_Origin)
+	if len(origin) == 0 {
+		if trace {
+			traceLogger.Print("no Http header Origin set")
+		}
+		chain.ProcessFilter(req, resp)
+		return
+	}
+	if !c.isOriginAllowed(origin) { // check whether this origin is allowed
+		if trace {
+			traceLogger.Printf("HTTP Origin:%s is not part of %v, neither matches any part of %v", origin, c.AllowedDomains, c.allowedOriginPatterns)
+		}
+		chain.ProcessFilter(req, resp)
+		return
+	}
+	if req.Request.Method != "OPTIONS" {
+		c.doActualRequest(req, resp)
+		chain.ProcessFilter(req, resp)
+		return
+	}
+	if acrm := req.Request.Header.Get(HEADER_AccessControlRequestMethod); acrm != "" {
+		c.doPreflightRequest(req, resp)
+	} else {
+		c.doActualRequest(req, resp)
+		chain.ProcessFilter(req, resp)
+		return
+	}
+}
+
+func (c CrossOriginResourceSharing) doActualRequest(req *Request, resp *Response) {
+	c.setOptionsHeaders(req, resp)
+	// continue processing the response
+}
+
+func (c *CrossOriginResourceSharing) doPreflightRequest(req *Request, resp *Response) {
+	if len(c.AllowedMethods) == 0 {
+		if c.Container == nil {
+			c.AllowedMethods = DefaultContainer.computeAllowedMethods(req)
+		} else {
+			c.AllowedMethods = c.Container.computeAllowedMethods(req)
+		}
+	}
+
+	acrm := req.Request.Header.Get(HEADER_AccessControlRequestMethod)
+	if !c.isValidAccessControlRequestMethod(acrm, c.AllowedMethods) {
+		if trace {
+			traceLogger.Printf("Http header %s:%s is not in %v",
+				HEADER_AccessControlRequestMethod,
+				acrm,
+				c.AllowedMethods)
+		}
+		return
+	}
+	acrhs := req.Request.Header.Get(HEADER_AccessControlRequestHeaders)
+	if len(acrhs) > 0 {
+		for _, each := range strings.Split(acrhs, ",") {
+			if !c.isValidAccessControlRequestHeader(strings.Trim(each, " ")) {
+				if trace {
+					traceLogger.Printf("Http header %s:%s is not in %v",
+						HEADER_AccessControlRequestHeaders,
+						acrhs,
+						c.AllowedHeaders)
+				}
+				return
+			}
+		}
+	}
+	resp.AddHeader(HEADER_AccessControlAllowMethods, strings.Join(c.AllowedMethods, ","))
+	resp.AddHeader(HEADER_AccessControlAllowHeaders, acrhs)
+	c.setOptionsHeaders(req, resp)
+
+	// return http 200 response, no body
+}
+
+func (c CrossOriginResourceSharing) setOptionsHeaders(req *Request, resp *Response) {
+	c.checkAndSetExposeHeaders(resp)
+	c.setAllowOriginHeader(req, resp)
+	c.checkAndSetAllowCredentials(resp)
+	if c.MaxAge > 0 {
+		resp.AddHeader(HEADER_AccessControlMaxAge, strconv.Itoa(c.MaxAge))
+	}
+}
+
+func (c CrossOriginResourceSharing) isOriginAllowed(origin string) bool {
+	if len(origin) == 0 {
+		return false
+	}
+	if len(c.AllowedDomains) == 0 {
+		return true
+	}
+
+	allowed := false
+	for _, domain := range c.AllowedDomains {
+		if domain == origin {
+			allowed = true
+			break
+		}
+	}
+
+	if !allowed {
+		if len(c.allowedOriginPatterns) == 0 {
+			// compile allowed domains to allowed origin patterns
+			allowedOriginRegexps, err := compileRegexps(c.AllowedDomains)
+			if err != nil {
+				return false
+			}
+			c.allowedOriginPatterns = allowedOriginRegexps
+		}
+
+		for _, pattern := range c.allowedOriginPatterns {
+			if allowed = pattern.MatchString(origin); allowed {
+				break
+			}
+		}
+	}
+
+	return allowed
+}
+
+func (c CrossOriginResourceSharing) setAllowOriginHeader(req *Request, resp *Response) {
+	origin := req.Request.Header.Get(HEADER_Origin)
+	if c.isOriginAllowed(origin) {
+		resp.AddHeader(HEADER_AccessControlAllowOrigin, origin)
+	}
+}
+
+func (c CrossOriginResourceSharing) checkAndSetExposeHeaders(resp *Response) {
+	if len(c.ExposeHeaders) > 0 {
+		resp.AddHeader(HEADER_AccessControlExposeHeaders, strings.Join(c.ExposeHeaders, ","))
+	}
+}
+
+func (c CrossOriginResourceSharing) checkAndSetAllowCredentials(resp *Response) {
+	if c.CookiesAllowed {
+		resp.AddHeader(HEADER_AccessControlAllowCredentials, "true")
+	}
+}
+
+func (c CrossOriginResourceSharing) isValidAccessControlRequestMethod(method string, allowedMethods []string) bool {
+	for _, each := range allowedMethods {
+		if each == method {
+			return true
+		}
+	}
+	return false
+}
+
+func (c CrossOriginResourceSharing) isValidAccessControlRequestHeader(header string) bool {
+	for _, each := range c.AllowedHeaders {
+		if strings.ToLower(each) == strings.ToLower(header) {
+			return true
+		}
+	}
+	return false
+}
+
+// Take a list of strings and compile them into a list of regular expressions.
+func compileRegexps(regexpStrings []string) ([]*regexp.Regexp, error) {
+	regexps := []*regexp.Regexp{}
+	for _, regexpStr := range regexpStrings {
+		r, err := regexp.Compile(regexpStr)
+		if err != nil {
+			return regexps, err
+		}
+		regexps = append(regexps, r)
+	}
+	return regexps, nil
+}

--- a/vendor/github.com/emicklei/go-restful/curly.go
+++ b/vendor/github.com/emicklei/go-restful/curly.go
@@ -1,0 +1,164 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// CurlyRouter expects Routes with paths that contain zero or more parameters in curly brackets.
+type CurlyRouter struct{}
+
+// SelectRoute is part of the Router interface and returns the best match
+// for the WebService and its Route for the given Request.
+func (c CurlyRouter) SelectRoute(
+	webServices []*WebService,
+	httpRequest *http.Request) (selectedService *WebService, selected *Route, err error) {
+
+	requestTokens := tokenizePath(httpRequest.URL.Path)
+
+	detectedService := c.detectWebService(requestTokens, webServices)
+	if detectedService == nil {
+		if trace {
+			traceLogger.Printf("no WebService was found to match URL path:%s\n", httpRequest.URL.Path)
+		}
+		return nil, nil, NewError(http.StatusNotFound, "404: Page Not Found")
+	}
+	candidateRoutes := c.selectRoutes(detectedService, requestTokens)
+	if len(candidateRoutes) == 0 {
+		if trace {
+			traceLogger.Printf("no Route in WebService with path %s was found to match URL path:%s\n", detectedService.rootPath, httpRequest.URL.Path)
+		}
+		return detectedService, nil, NewError(http.StatusNotFound, "404: Page Not Found")
+	}
+	selectedRoute, err := c.detectRoute(candidateRoutes, httpRequest)
+	if selectedRoute == nil {
+		return detectedService, nil, err
+	}
+	return detectedService, selectedRoute, nil
+}
+
+// selectRoutes return a collection of Route from a WebService that matches the path tokens from the request.
+func (c CurlyRouter) selectRoutes(ws *WebService, requestTokens []string) sortableCurlyRoutes {
+	candidates := sortableCurlyRoutes{}
+	for _, each := range ws.routes {
+		matches, paramCount, staticCount := c.matchesRouteByPathTokens(each.pathParts, requestTokens)
+		if matches {
+			candidates.add(curlyRoute{each, paramCount, staticCount}) // TODO make sure Routes() return pointers?
+		}
+	}
+	sort.Sort(sort.Reverse(candidates))
+	return candidates
+}
+
+// matchesRouteByPathTokens computes whether it matches, howmany parameters do match and what the number of static path elements are.
+func (c CurlyRouter) matchesRouteByPathTokens(routeTokens, requestTokens []string) (matches bool, paramCount int, staticCount int) {
+	if len(routeTokens) < len(requestTokens) {
+		// proceed in matching only if last routeToken is wildcard
+		count := len(routeTokens)
+		if count == 0 || !strings.HasSuffix(routeTokens[count-1], "*}") {
+			return false, 0, 0
+		}
+		// proceed
+	}
+	for i, routeToken := range routeTokens {
+		if i == len(requestTokens) {
+			// reached end of request path
+			return false, 0, 0
+		}
+		requestToken := requestTokens[i]
+		if strings.HasPrefix(routeToken, "{") {
+			paramCount++
+			if colon := strings.Index(routeToken, ":"); colon != -1 {
+				// match by regex
+				matchesToken, matchesRemainder := c.regularMatchesPathToken(routeToken, colon, requestToken)
+				if !matchesToken {
+					return false, 0, 0
+				}
+				if matchesRemainder {
+					break
+				}
+			}
+		} else { // no { prefix
+			if requestToken != routeToken {
+				return false, 0, 0
+			}
+			staticCount++
+		}
+	}
+	return true, paramCount, staticCount
+}
+
+// regularMatchesPathToken tests whether the regular expression part of routeToken matches the requestToken or all remaining tokens
+// format routeToken is {someVar:someExpression}, e.g. {zipcode:[\d][\d][\d][\d][A-Z][A-Z]}
+func (c CurlyRouter) regularMatchesPathToken(routeToken string, colon int, requestToken string) (matchesToken bool, matchesRemainder bool) {
+	regPart := routeToken[colon+1 : len(routeToken)-1]
+	if regPart == "*" {
+		if trace {
+			traceLogger.Printf("wildcard parameter detected in route token %s that matches %s\n", routeToken, requestToken)
+		}
+		return true, true
+	}
+	matched, err := regexp.MatchString(regPart, requestToken)
+	return (matched && err == nil), false
+}
+
+var jsr311Router = RouterJSR311{}
+
+// detectRoute selectes from a list of Route the first match by inspecting both the Accept and Content-Type
+// headers of the Request. See also RouterJSR311 in jsr311.go
+func (c CurlyRouter) detectRoute(candidateRoutes sortableCurlyRoutes, httpRequest *http.Request) (*Route, error) {
+	// tracing is done inside detectRoute
+	return jsr311Router.detectRoute(candidateRoutes.routes(), httpRequest)
+}
+
+// detectWebService returns the best matching webService given the list of path tokens.
+// see also computeWebserviceScore
+func (c CurlyRouter) detectWebService(requestTokens []string, webServices []*WebService) *WebService {
+	var best *WebService
+	score := -1
+	for _, each := range webServices {
+		matches, eachScore := c.computeWebserviceScore(requestTokens, each.pathExpr.tokens)
+		if matches && (eachScore > score) {
+			best = each
+			score = eachScore
+		}
+	}
+	return best
+}
+
+// computeWebserviceScore returns whether tokens match and
+// the weighted score of the longest matching consecutive tokens from the beginning.
+func (c CurlyRouter) computeWebserviceScore(requestTokens []string, tokens []string) (bool, int) {
+	if len(tokens) > len(requestTokens) {
+		return false, 0
+	}
+	score := 0
+	for i := 0; i < len(tokens); i++ {
+		each := requestTokens[i]
+		other := tokens[i]
+		if len(each) == 0 && len(other) == 0 {
+			score++
+			continue
+		}
+		if len(other) > 0 && strings.HasPrefix(other, "{") {
+			// no empty match
+			if len(each) == 0 {
+				return false, score
+			}
+			score += 1
+		} else {
+			// not a parameter
+			if each != other {
+				return false, score
+			}
+			score += (len(tokens) - i) * 10 //fuzzy
+		}
+	}
+	return true, score
+}

--- a/vendor/github.com/emicklei/go-restful/curly_route.go
+++ b/vendor/github.com/emicklei/go-restful/curly_route.go
@@ -1,0 +1,52 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+// curlyRoute exits for sorting Routes by the CurlyRouter based on number of parameters and number of static path elements.
+type curlyRoute struct {
+	route       Route
+	paramCount  int
+	staticCount int
+}
+
+type sortableCurlyRoutes []curlyRoute
+
+func (s *sortableCurlyRoutes) add(route curlyRoute) {
+	*s = append(*s, route)
+}
+
+func (s sortableCurlyRoutes) routes() (routes []Route) {
+	for _, each := range s {
+		routes = append(routes, each.route) // TODO change return type
+	}
+	return routes
+}
+
+func (s sortableCurlyRoutes) Len() int {
+	return len(s)
+}
+func (s sortableCurlyRoutes) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s sortableCurlyRoutes) Less(i, j int) bool {
+	ci := s[i]
+	cj := s[j]
+
+	// primary key
+	if ci.staticCount < cj.staticCount {
+		return true
+	}
+	if ci.staticCount > cj.staticCount {
+		return false
+	}
+	// secundary key
+	if ci.paramCount < cj.paramCount {
+		return true
+	}
+	if ci.paramCount > cj.paramCount {
+		return false
+	}
+	return ci.route.Path < cj.route.Path
+}

--- a/vendor/github.com/emicklei/go-restful/doc.go
+++ b/vendor/github.com/emicklei/go-restful/doc.go
@@ -1,0 +1,185 @@
+/*
+Package restful, a lean package for creating REST-style WebServices without magic.
+
+WebServices and Routes
+
+A WebService has a collection of Route objects that dispatch incoming Http Requests to a function calls.
+Typically, a WebService has a root path (e.g. /users) and defines common MIME types for its routes.
+WebServices must be added to a container (see below) in order to handler Http requests from a server.
+
+A Route is defined by a HTTP method, an URL path and (optionally) the MIME types it consumes (Content-Type) and produces (Accept).
+This package has the logic to find the best matching Route and if found, call its Function.
+
+	ws := new(restful.WebService)
+	ws.
+		Path("/users").
+		Consumes(restful.MIME_JSON, restful.MIME_XML).
+		Produces(restful.MIME_JSON, restful.MIME_XML)
+
+	ws.Route(ws.GET("/{user-id}").To(u.findUser))  // u is a UserResource
+
+	...
+
+	// GET http://localhost:8080/users/1
+	func (u UserResource) findUser(request *restful.Request, response *restful.Response) {
+		id := request.PathParameter("user-id")
+		...
+	}
+
+The (*Request, *Response) arguments provide functions for reading information from the request and writing information back to the response.
+
+See the example https://github.com/emicklei/go-restful/blob/master/examples/restful-user-resource.go with a full implementation.
+
+Regular expression matching Routes
+
+A Route parameter can be specified using the format "uri/{var[:regexp]}" or the special version "uri/{var:*}" for matching the tail of the path.
+For example, /persons/{name:[A-Z][A-Z]} can be used to restrict values for the parameter "name" to only contain capital alphabetic characters.
+Regular expressions must use the standard Go syntax as described in the regexp package. (https://code.google.com/p/re2/wiki/Syntax)
+This feature requires the use of a CurlyRouter.
+
+Containers
+
+A Container holds a collection of WebServices, Filters and a http.ServeMux for multiplexing http requests.
+Using the statements "restful.Add(...) and restful.Filter(...)" will register WebServices and Filters to the Default Container.
+The Default container of go-restful uses the http.DefaultServeMux.
+You can create your own Container and create a new http.Server for that particular container.
+
+	container := restful.NewContainer()
+	server := &http.Server{Addr: ":8081", Handler: container}
+
+Filters
+
+A filter dynamically intercepts requests and responses to transform or use the information contained in the requests or responses.
+You can use filters to perform generic logging, measurement, authentication, redirect, set response headers etc.
+In the restful package there are three hooks into the request,response flow where filters can be added.
+Each filter must define a FilterFunction:
+
+	func (req *restful.Request, resp *restful.Response, chain *restful.FilterChain)
+
+Use the following statement to pass the request,response pair to the next filter or RouteFunction
+
+	chain.ProcessFilter(req, resp)
+
+Container Filters
+
+These are processed before any registered WebService.
+
+	// install a (global) filter for the default container (processed before any webservice)
+	restful.Filter(globalLogging)
+
+WebService Filters
+
+These are processed before any Route of a WebService.
+
+	// install a webservice filter (processed before any route)
+	ws.Filter(webserviceLogging).Filter(measureTime)
+
+
+Route Filters
+
+These are processed before calling the function associated with the Route.
+
+	// install 2 chained route filters (processed before calling findUser)
+	ws.Route(ws.GET("/{user-id}").Filter(routeLogging).Filter(NewCountFilter().routeCounter).To(findUser))
+
+See the example https://github.com/emicklei/go-restful/blob/master/examples/restful-filters.go with full implementations.
+
+Response Encoding
+
+Two encodings are supported: gzip and deflate. To enable this for all responses:
+
+	restful.DefaultContainer.EnableContentEncoding(true)
+
+If a Http request includes the Accept-Encoding header then the response content will be compressed using the specified encoding.
+Alternatively, you can create a Filter that performs the encoding and install it per WebService or Route.
+
+See the example https://github.com/emicklei/go-restful/blob/master/examples/restful-encoding-filter.go
+
+OPTIONS support
+
+By installing a pre-defined container filter, your Webservice(s) can respond to the OPTIONS Http request.
+
+	Filter(OPTIONSFilter())
+
+CORS
+
+By installing the filter of a CrossOriginResourceSharing (CORS), your WebService(s) can handle CORS requests.
+
+	cors := CrossOriginResourceSharing{ExposeHeaders: []string{"X-My-Header"}, CookiesAllowed: false, Container: DefaultContainer}
+	Filter(cors.Filter)
+
+Error Handling
+
+Unexpected things happen. If a request cannot be processed because of a failure, your service needs to tell via the response what happened and why.
+For this reason HTTP status codes exist and it is important to use the correct code in every exceptional situation.
+
+	400: Bad Request
+
+If path or query parameters are not valid (content or type) then use http.StatusBadRequest.
+
+	404: Not Found
+
+Despite a valid URI, the resource requested may not be available
+
+	500: Internal Server Error
+
+If the application logic could not process the request (or write the response) then use http.StatusInternalServerError.
+
+	405: Method Not Allowed
+
+The request has a valid URL but the method (GET,PUT,POST,...) is not allowed.
+
+	406: Not Acceptable
+
+The request does not have or has an unknown Accept Header set for this operation.
+
+	415: Unsupported Media Type
+
+The request does not have or has an unknown Content-Type Header set for this operation.
+
+ServiceError
+
+In addition to setting the correct (error) Http status code, you can choose to write a ServiceError message on the response.
+
+Performance options
+
+This package has several options that affect the performance of your service. It is important to understand them and how you can change it.
+
+	restful.DefaultContainer.DoNotRecover(false)
+
+DoNotRecover controls whether panics will be caught to return HTTP 500.
+If set to false, the container will recover from panics.
+Default value is true
+
+	restful.SetCompressorProvider(NewBoundedCachedCompressors(20, 20))
+
+If content encoding is enabled then the default strategy for getting new gzip/zlib writers and readers is to use a sync.Pool.
+Because writers are expensive structures, performance is even more improved when using a preloaded cache. You can also inject your own implementation.
+
+Trouble shooting
+
+This package has the means to produce detail logging of the complete Http request matching process and filter invocation.
+Enabling this feature requires you to set an implementation of restful.StdLogger (e.g. log.Logger) instance such as:
+
+	restful.TraceLogger(log.New(os.Stdout, "[restful] ", log.LstdFlags|log.Lshortfile))
+
+Logging
+
+The restful.SetLogger() method allows you to override the logger used by the package. By default restful
+uses the standard library `log` package and logs to stdout. Different logging packages are supported as
+long as they conform to `StdLogger` interface defined in the `log` sub-package, writing an adapter for your
+preferred package is simple.
+
+Resources
+
+[project]: https://github.com/emicklei/go-restful
+
+[examples]: https://github.com/emicklei/go-restful/blob/master/examples
+
+[design]:  http://ernestmicklei.com/2012/11/11/go-restful-api-design/
+
+[showcases]: https://github.com/emicklei/mora, https://github.com/emicklei/landskape
+
+(c) 2012-2015, http://ernestmicklei.com. MIT License
+*/
+package restful

--- a/vendor/github.com/emicklei/go-restful/entity_accessors.go
+++ b/vendor/github.com/emicklei/go-restful/entity_accessors.go
@@ -1,0 +1,163 @@
+package restful
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"strings"
+	"sync"
+)
+
+// EntityReaderWriter can read and write values using an encoding such as JSON,XML.
+type EntityReaderWriter interface {
+	// Read a serialized version of the value from the request.
+	// The Request may have a decompressing reader. Depends on Content-Encoding.
+	Read(req *Request, v interface{}) error
+
+	// Write a serialized version of the value on the response.
+	// The Response may have a compressing writer. Depends on Accept-Encoding.
+	// status should be a valid Http Status code
+	Write(resp *Response, status int, v interface{}) error
+}
+
+// entityAccessRegistry is a singleton
+var entityAccessRegistry = &entityReaderWriters{
+	protection: new(sync.RWMutex),
+	accessors:  map[string]EntityReaderWriter{},
+}
+
+// entityReaderWriters associates MIME to an EntityReaderWriter
+type entityReaderWriters struct {
+	protection *sync.RWMutex
+	accessors  map[string]EntityReaderWriter
+}
+
+func init() {
+	RegisterEntityAccessor(MIME_JSON, NewEntityAccessorJSON(MIME_JSON))
+	RegisterEntityAccessor(MIME_XML, NewEntityAccessorXML(MIME_XML))
+}
+
+// RegisterEntityAccessor add/overrides the ReaderWriter for encoding content with this MIME type.
+func RegisterEntityAccessor(mime string, erw EntityReaderWriter) {
+	entityAccessRegistry.protection.Lock()
+	defer entityAccessRegistry.protection.Unlock()
+	entityAccessRegistry.accessors[mime] = erw
+}
+
+// NewEntityAccessorJSON returns a new EntityReaderWriter for accessing JSON content.
+// This package is already initialized with such an accessor using the MIME_JSON contentType.
+func NewEntityAccessorJSON(contentType string) EntityReaderWriter {
+	return entityJSONAccess{ContentType: contentType}
+}
+
+// NewEntityAccessorXML returns a new EntityReaderWriter for accessing XML content.
+// This package is already initialized with such an accessor using the MIME_XML contentType.
+func NewEntityAccessorXML(contentType string) EntityReaderWriter {
+	return entityXMLAccess{ContentType: contentType}
+}
+
+// accessorAt returns the registered ReaderWriter for this MIME type.
+func (r *entityReaderWriters) accessorAt(mime string) (EntityReaderWriter, bool) {
+	r.protection.RLock()
+	defer r.protection.RUnlock()
+	er, ok := r.accessors[mime]
+	if !ok {
+		// retry with reverse lookup
+		// more expensive but we are in an exceptional situation anyway
+		for k, v := range r.accessors {
+			if strings.Contains(mime, k) {
+				return v, true
+			}
+		}
+	}
+	return er, ok
+}
+
+// entityXMLAccess is a EntityReaderWriter for XML encoding
+type entityXMLAccess struct {
+	// This is used for setting the Content-Type header when writing
+	ContentType string
+}
+
+// Read unmarshalls the value from XML
+func (e entityXMLAccess) Read(req *Request, v interface{}) error {
+	return xml.NewDecoder(req.Request.Body).Decode(v)
+}
+
+// Write marshalls the value to JSON and set the Content-Type Header.
+func (e entityXMLAccess) Write(resp *Response, status int, v interface{}) error {
+	return writeXML(resp, status, e.ContentType, v)
+}
+
+// writeXML marshalls the value to JSON and set the Content-Type Header.
+func writeXML(resp *Response, status int, contentType string, v interface{}) error {
+	if v == nil {
+		resp.WriteHeader(status)
+		// do not write a nil representation
+		return nil
+	}
+	if resp.prettyPrint {
+		// pretty output must be created and written explicitly
+		output, err := xml.MarshalIndent(v, " ", " ")
+		if err != nil {
+			return err
+		}
+		resp.Header().Set(HEADER_ContentType, contentType)
+		resp.WriteHeader(status)
+		_, err = resp.Write([]byte(xml.Header))
+		if err != nil {
+			return err
+		}
+		_, err = resp.Write(output)
+		return err
+	}
+	// not-so-pretty
+	resp.Header().Set(HEADER_ContentType, contentType)
+	resp.WriteHeader(status)
+	return xml.NewEncoder(resp).Encode(v)
+}
+
+// entityJSONAccess is a EntityReaderWriter for JSON encoding
+type entityJSONAccess struct {
+	// This is used for setting the Content-Type header when writing
+	ContentType string
+}
+
+// Read unmarshalls the value from JSON
+func (e entityJSONAccess) Read(req *Request, v interface{}) error {
+	decoder := json.NewDecoder(req.Request.Body)
+	decoder.UseNumber()
+	return decoder.Decode(v)
+}
+
+// Write marshalls the value to JSON and set the Content-Type Header.
+func (e entityJSONAccess) Write(resp *Response, status int, v interface{}) error {
+	return writeJSON(resp, status, e.ContentType, v)
+}
+
+// write marshalls the value to JSON and set the Content-Type Header.
+func writeJSON(resp *Response, status int, contentType string, v interface{}) error {
+	if v == nil {
+		resp.WriteHeader(status)
+		// do not write a nil representation
+		return nil
+	}
+	if resp.prettyPrint {
+		// pretty output must be created and written explicitly
+		output, err := json.MarshalIndent(v, " ", " ")
+		if err != nil {
+			return err
+		}
+		resp.Header().Set(HEADER_ContentType, contentType)
+		resp.WriteHeader(status)
+		_, err = resp.Write(output)
+		return err
+	}
+	// not-so-pretty
+	resp.Header().Set(HEADER_ContentType, contentType)
+	resp.WriteHeader(status)
+	return json.NewEncoder(resp).Encode(v)
+}

--- a/vendor/github.com/emicklei/go-restful/examples/google_app_engine/datastore/main.go
+++ b/vendor/github.com/emicklei/go-restful/examples/google_app_engine/datastore/main.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/swagger"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/datastore"
+	"google.golang.org/appengine/user"
+	"net/http"
+	"time"
+)
+
+// This example demonstrates a reasonably complete suite of RESTful operations backed
+// by DataStore on Google App Engine.
+
+// Our simple example struct.
+type Profile struct {
+	LastModified time.Time `json:"-" xml:"-"`
+	Email        string    `json:"-" xml:"-"`
+	FirstName    string    `json:"first_name" xml:"first-name"`
+	NickName     string    `json:"nick_name" xml:"nick-name"`
+	LastName     string    `json:"last_name" xml:"last-name"`
+}
+
+type ProfileApi struct {
+	Path string
+}
+
+func gaeUrl() string {
+	if appengine.IsDevAppServer() {
+		return "http://localhost:8080"
+	} else {
+		// Include your URL on App Engine here.
+		// I found no way to get AppID without appengine.Context and this always
+		// based on a http.Request.
+		return "http://federatedservices.appspot.com"
+	}
+}
+
+func init() {
+	u := ProfileApi{Path: "/profiles"}
+	u.register()
+
+	// Optionally, you can install the Swagger Service which provides a nice Web UI on your REST API
+	// You need to download the Swagger HTML5 assets and change the FilePath location in the config below.
+	// Open <your_app_id>.appspot.com/apidocs and enter
+	// Place the Swagger UI files into a folder called static/swagger if you wish to use Swagger
+	// http://<your_app_id>.appspot.com/apidocs.json in the api input field.
+	// For testing, you can use http://localhost:8080/apidocs.json
+	config := swagger.Config{
+		// You control what services are visible
+		WebServices:    restful.RegisteredWebServices(),
+		WebServicesUrl: gaeUrl(),
+		ApiPath:        "/apidocs.json",
+
+		// Optionally, specifiy where the UI is located
+		SwaggerPath: "/apidocs/",
+
+		// GAE support static content which is configured in your app.yaml.
+		// This example expect the swagger-ui in static/swagger so you should place it there :)
+		SwaggerFilePath: "static/swagger"}
+	swagger.InstallSwaggerService(config)
+}
+
+func (u ProfileApi) register() {
+	ws := new(restful.WebService)
+
+	ws.
+		Path(u.Path).
+		// You can specify consumes and produces per route as well.
+		Consumes(restful.MIME_JSON, restful.MIME_XML).
+		Produces(restful.MIME_JSON, restful.MIME_XML)
+
+	ws.Route(ws.POST("").To(u.insert).
+		// Swagger documentation.
+		Doc("insert a new profile").
+		Param(ws.BodyParameter("Profile", "representation of a profile").DataType("main.Profile")).
+		Reads(Profile{}))
+
+	ws.Route(ws.GET("/{profile-id}").To(u.read).
+		// Swagger documentation.
+		Doc("read a profile").
+		Param(ws.PathParameter("profile-id", "identifier for a profile").DataType("string")).
+		Writes(Profile{}))
+
+	ws.Route(ws.PUT("/{profile-id}").To(u.update).
+		// Swagger documentation.
+		Doc("update an existing profile").
+		Param(ws.PathParameter("profile-id", "identifier for a profile").DataType("string")).
+		Param(ws.BodyParameter("Profile", "representation of a profile").DataType("main.Profile")).
+		Reads(Profile{}))
+
+	ws.Route(ws.DELETE("/{profile-id}").To(u.remove).
+		// Swagger documentation.
+		Doc("remove a profile").
+		Param(ws.PathParameter("profile-id", "identifier for a profile").DataType("string")))
+
+	restful.Add(ws)
+}
+
+// POST http://localhost:8080/profiles
+// {"first_name": "Ivan", "nick_name": "Socks", "last_name": "Hawkes"}
+//
+func (u *ProfileApi) insert(r *restful.Request, w *restful.Response) {
+	c := appengine.NewContext(r.Request)
+
+	// Marshall the entity from the request into a struct.
+	p := new(Profile)
+	err := r.ReadEntity(&p)
+	if err != nil {
+		w.WriteError(http.StatusNotAcceptable, err)
+		return
+	}
+
+	// Ensure we start with a sensible value for this field.
+	p.LastModified = time.Now()
+
+	// The profile belongs to this user.
+	p.Email = user.Current(c).String()
+
+	k, err := datastore.Put(c, datastore.NewIncompleteKey(c, "profiles", nil), p)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Let them know the location of the newly created resource.
+	// TODO: Use a safe Url path append function.
+	w.AddHeader("Location", u.Path+"/"+k.Encode())
+
+	// Return the resultant entity.
+	w.WriteHeader(http.StatusCreated)
+	w.WriteEntity(p)
+}
+
+// GET http://localhost:8080/profiles/ahdkZXZ-ZmVkZXJhdGlvbi1zZXJ2aWNlc3IVCxIIcHJvZmlsZXMYgICAgICAgAoM
+//
+func (u ProfileApi) read(r *restful.Request, w *restful.Response) {
+	c := appengine.NewContext(r.Request)
+
+	// Decode the request parameter to determine the key for the entity.
+	k, err := datastore.DecodeKey(r.PathParameter("profile-id"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Retrieve the entity from the datastore.
+	p := Profile{}
+	if err := datastore.Get(c, k, &p); err != nil {
+		if err.Error() == "datastore: no such entity" {
+			http.Error(w, err.Error(), http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// Check we own the profile before allowing them to view it.
+	// Optionally, return a 404 instead to help prevent guessing ids.
+	// TODO: Allow admins access.
+	if p.Email != user.Current(c).String() {
+		http.Error(w, "You do not have access to this resource", http.StatusForbidden)
+		return
+	}
+
+	w.WriteEntity(p)
+}
+
+// PUT http://localhost:8080/profiles/ahdkZXZ-ZmVkZXJhdGlvbi1zZXJ2aWNlc3IVCxIIcHJvZmlsZXMYgICAgICAgAoM
+// {"first_name": "Ivan", "nick_name": "Socks", "last_name": "Hawkes"}
+//
+func (u *ProfileApi) update(r *restful.Request, w *restful.Response) {
+	c := appengine.NewContext(r.Request)
+
+	// Decode the request parameter to determine the key for the entity.
+	k, err := datastore.DecodeKey(r.PathParameter("profile-id"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Marshall the entity from the request into a struct.
+	p := new(Profile)
+	err = r.ReadEntity(&p)
+	if err != nil {
+		w.WriteError(http.StatusNotAcceptable, err)
+		return
+	}
+
+	// Retrieve the old entity from the datastore.
+	old := Profile{}
+	if err := datastore.Get(c, k, &old); err != nil {
+		if err.Error() == "datastore: no such entity" {
+			http.Error(w, err.Error(), http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// Check we own the profile before allowing them to update it.
+	// Optionally, return a 404 instead to help prevent guessing ids.
+	// TODO: Allow admins access.
+	if old.Email != user.Current(c).String() {
+		http.Error(w, "You do not have access to this resource", http.StatusForbidden)
+		return
+	}
+
+	// Since the whole entity is re-written, we need to assign any invariant fields again
+	// e.g. the owner of the entity.
+	p.Email = user.Current(c).String()
+
+	// Keep track of the last modification date.
+	p.LastModified = time.Now()
+
+	// Attempt to overwrite the old entity.
+	_, err = datastore.Put(c, k, p)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Let them know it succeeded.
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// DELETE http://localhost:8080/profiles/ahdkZXZ-ZmVkZXJhdGlvbi1zZXJ2aWNlc3IVCxIIcHJvZmlsZXMYgICAgICAgAoM
+//
+func (u *ProfileApi) remove(r *restful.Request, w *restful.Response) {
+	c := appengine.NewContext(r.Request)
+
+	// Decode the request parameter to determine the key for the entity.
+	k, err := datastore.DecodeKey(r.PathParameter("profile-id"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Retrieve the old entity from the datastore.
+	old := Profile{}
+	if err := datastore.Get(c, k, &old); err != nil {
+		if err.Error() == "datastore: no such entity" {
+			http.Error(w, err.Error(), http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// Check we own the profile before allowing them to delete it.
+	// Optionally, return a 404 instead to help prevent guessing ids.
+	// TODO: Allow admins access.
+	if old.Email != user.Current(c).String() {
+		http.Error(w, "You do not have access to this resource", http.StatusForbidden)
+		return
+	}
+
+	// Delete the entity.
+	if err := datastore.Delete(c, k); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+	// Success notification.
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/vendor/github.com/emicklei/go-restful/examples/google_app_engine/restful-appstats-integration.go
+++ b/vendor/github.com/emicklei/go-restful/examples/google_app_engine/restful-appstats-integration.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/mjibson/appstats"
+)
+
+func stats(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	c := appstats.NewContext(req.Request)
+	chain.ProcessFilter(req, resp)
+	c.Stats.Status = resp.StatusCode()
+	c.Save()
+}

--- a/vendor/github.com/emicklei/go-restful/examples/google_app_engine/restful-user-service.go
+++ b/vendor/github.com/emicklei/go-restful/examples/google_app_engine/restful-user-service.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/swagger"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/memcache"
+	"net/http"
+)
+
+// This example is functionally the same as ../restful-user-service.go
+// but it`s supposed to run on Goole App Engine (GAE)
+//
+// contributed by ivanhawkes
+
+type User struct {
+	Id, Name string
+}
+
+type UserService struct {
+	// normally one would use DAO (data access object)
+	// but in this example we simple use memcache.
+}
+
+func (u UserService) Register() {
+	ws := new(restful.WebService)
+
+	ws.
+		Path("/users").
+		Consumes(restful.MIME_XML, restful.MIME_JSON).
+		Produces(restful.MIME_JSON, restful.MIME_XML) // you can specify this per route as well
+
+	ws.Route(ws.GET("/{user-id}").To(u.findUser).
+		// docs
+		Doc("get a user").
+		Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")).
+		Writes(User{})) // on the response
+
+	ws.Route(ws.PATCH("").To(u.updateUser).
+		// docs
+		Doc("update a user").
+		Reads(User{})) // from the request
+
+	ws.Route(ws.PUT("/{user-id}").To(u.createUser).
+		// docs
+		Doc("create a user").
+		Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")).
+		Reads(User{})) // from the request
+
+	ws.Route(ws.DELETE("/{user-id}").To(u.removeUser).
+		// docs
+		Doc("delete a user").
+		Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")))
+
+	restful.Add(ws)
+}
+
+// GET http://localhost:8080/users/1
+//
+func (u UserService) findUser(request *restful.Request, response *restful.Response) {
+	c := appengine.NewContext(request.Request)
+	id := request.PathParameter("user-id")
+	usr := new(User)
+	_, err := memcache.Gob.Get(c, id, &usr)
+	if err != nil || len(usr.Id) == 0 {
+		response.WriteErrorString(http.StatusNotFound, "User could not be found.")
+	} else {
+		response.WriteEntity(usr)
+	}
+}
+
+// PATCH http://localhost:8080/users
+// <User><Id>1</Id><Name>Melissa Raspberry</Name></User>
+//
+func (u *UserService) updateUser(request *restful.Request, response *restful.Response) {
+	c := appengine.NewContext(request.Request)
+	usr := new(User)
+	err := request.ReadEntity(&usr)
+	if err == nil {
+		item := &memcache.Item{
+			Key:    usr.Id,
+			Object: &usr,
+		}
+		err = memcache.Gob.Set(c, item)
+		if err != nil {
+			response.WriteError(http.StatusInternalServerError, err)
+			return
+		}
+		response.WriteEntity(usr)
+	} else {
+		response.WriteError(http.StatusInternalServerError, err)
+	}
+}
+
+// PUT http://localhost:8080/users/1
+// <User><Id>1</Id><Name>Melissa</Name></User>
+//
+func (u *UserService) createUser(request *restful.Request, response *restful.Response) {
+	c := appengine.NewContext(request.Request)
+	usr := User{Id: request.PathParameter("user-id")}
+	err := request.ReadEntity(&usr)
+	if err == nil {
+		item := &memcache.Item{
+			Key:    usr.Id,
+			Object: &usr,
+		}
+		err = memcache.Gob.Add(c, item)
+		if err != nil {
+			response.WriteError(http.StatusInternalServerError, err)
+			return
+		}
+		response.WriteHeader(http.StatusCreated)
+		response.WriteEntity(usr)
+	} else {
+		response.WriteError(http.StatusInternalServerError, err)
+	}
+}
+
+// DELETE http://localhost:8080/users/1
+//
+func (u *UserService) removeUser(request *restful.Request, response *restful.Response) {
+	c := appengine.NewContext(request.Request)
+	id := request.PathParameter("user-id")
+	err := memcache.Delete(c, id)
+	if err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+	}
+}
+
+func getGaeURL() string {
+	if appengine.IsDevAppServer() {
+		return "http://localhost:8080"
+	} else {
+		/**
+		 * Include your URL on App Engine here.
+		 * I found no way to get AppID without appengine.Context and this always
+		 * based on a http.Request.
+		 */
+		return "http://<your_app_id>.appspot.com"
+	}
+}
+
+func init() {
+	u := UserService{}
+	u.Register()
+
+	// Optionally, you can install the Swagger Service which provides a nice Web UI on your REST API
+	// You need to download the Swagger HTML5 assets and change the FilePath location in the config below.
+	// Open <your_app_id>.appspot.com/apidocs and enter http://<your_app_id>.appspot.com/apidocs.json in the api input field.
+	config := swagger.Config{
+		WebServices:    restful.RegisteredWebServices(), // you control what services are visible
+		WebServicesUrl: getGaeURL(),
+		ApiPath:        "/apidocs.json",
+
+		// Optionally, specifiy where the UI is located
+		SwaggerPath: "/apidocs/",
+		// GAE support static content which is configured in your app.yaml.
+		// This example expect the swagger-ui in static/swagger so you should place it there :)
+		SwaggerFilePath: "static/swagger"}
+	swagger.InstallSwaggerService(config)
+}

--- a/vendor/github.com/emicklei/go-restful/examples/msgpack/msgpack_entity.go
+++ b/vendor/github.com/emicklei/go-restful/examples/msgpack/msgpack_entity.go
@@ -1,0 +1,34 @@
+package restPack
+
+import (
+	restful "github.com/emicklei/go-restful"
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+const MIME_MSGPACK = "application/x-msgpack" // Accept or Content-Type used in Consumes() and/or Produces()
+
+// NewEntityAccessorMPack returns a new EntityReaderWriter for accessing MessagePack content.
+// This package is not initialized with such an accessor using the MIME_MSGPACK contentType.
+func NewEntityAccessorMsgPack() restful.EntityReaderWriter {
+	return entityMsgPackAccess{}
+}
+
+// entityOctetAccess is a EntityReaderWriter for Octet encoding
+type entityMsgPackAccess struct {
+}
+
+// Read unmarshalls the value from byte slice and using msgpack to unmarshal
+func (e entityMsgPackAccess) Read(req *restful.Request, v interface{}) error {
+	return msgpack.NewDecoder(req.Request.Body).Decode(v)
+}
+
+// Write marshals the value to byte slice and set the Content-Type Header.
+func (e entityMsgPackAccess) Write(resp *restful.Response, status int, v interface{}) error {
+	if v == nil {
+		resp.WriteHeader(status)
+		// do not write a nil representation
+		return nil
+	}
+	resp.WriteHeader(status)
+	return msgpack.NewEncoder(resp).Encode(v)
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-CORS-filter.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-CORS-filter.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/emicklei/go-restful"
+)
+
+// Cross-origin resource sharing (CORS) is a mechanism that allows JavaScript on a web page
+// to make XMLHttpRequests to another domain, not the domain the JavaScript originated from.
+//
+// http://en.wikipedia.org/wiki/Cross-origin_resource_sharing
+// http://enable-cors.org/server.html
+//
+// GET http://localhost:8080/users
+//
+// GET http://localhost:8080/users/1
+//
+// PUT http://localhost:8080/users/1
+//
+// DELETE http://localhost:8080/users/1
+//
+// OPTIONS http://localhost:8080/users/1  with Header "Origin" set to some domain and
+
+type UserResource struct{}
+
+func (u UserResource) RegisterTo(container *restful.Container) {
+	ws := new(restful.WebService)
+	ws.
+		Path("/users").
+		Consumes("*/*").
+		Produces("*/*")
+
+	ws.Route(ws.GET("/{user-id}").To(u.nop))
+	ws.Route(ws.POST("").To(u.nop))
+	ws.Route(ws.PUT("/{user-id}").To(u.nop))
+	ws.Route(ws.DELETE("/{user-id}").To(u.nop))
+
+	container.Add(ws)
+}
+
+func (u UserResource) nop(request *restful.Request, response *restful.Response) {
+	io.WriteString(response.ResponseWriter, "this would be a normal response")
+}
+
+func main() {
+	wsContainer := restful.NewContainer()
+	u := UserResource{}
+	u.RegisterTo(wsContainer)
+
+	// Add container filter to enable CORS
+	cors := restful.CrossOriginResourceSharing{
+		ExposeHeaders:  []string{"X-My-Header"},
+		AllowedHeaders: []string{"Content-Type", "Accept"},
+		AllowedMethods: []string{"GET", "POST"},
+		CookiesAllowed: false,
+		Container:      wsContainer}
+	wsContainer.Filter(cors.Filter)
+
+	// Add container filter to respond to OPTIONS
+	wsContainer.Filter(wsContainer.OPTIONSFilter)
+
+	log.Printf("start listening on localhost:8080")
+	server := &http.Server{Addr: ":8080", Handler: wsContainer}
+	log.Fatal(server.ListenAndServe())
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-NCSA-logging.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-NCSA-logging.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// This example shows how to create a filter that produces log lines
+// according to the Common Log Format, also known as the NCSA standard.
+//
+// kindly contributed by leehambley
+//
+// GET http://localhost:8080/ping
+
+var logger *log.Logger = log.New(os.Stdout, "", 0)
+
+func NCSACommonLogFormatLogger() restful.FilterFunction {
+	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+		var username = "-"
+		if req.Request.URL.User != nil {
+			if name := req.Request.URL.User.Username(); name != "" {
+				username = name
+			}
+		}
+		chain.ProcessFilter(req, resp)
+		logger.Printf("%s - %s [%s] \"%s %s %s\" %d %d",
+			strings.Split(req.Request.RemoteAddr, ":")[0],
+			username,
+			time.Now().Format("02/Jan/2006:15:04:05 -0700"),
+			req.Request.Method,
+			req.Request.URL.RequestURI(),
+			req.Request.Proto,
+			resp.StatusCode(),
+			resp.ContentLength(),
+		)
+	}
+}
+
+func main() {
+	ws := new(restful.WebService)
+	ws.Filter(NCSACommonLogFormatLogger())
+	ws.Route(ws.GET("/ping").To(hello))
+	restful.Add(ws)
+	http.ListenAndServe(":8080", nil)
+}
+
+func hello(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "pong")
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-basic-authentication.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-basic-authentication.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"io"
+	"net/http"
+)
+
+// This example shows how to create a (Route) Filter that performs Basic Authentication on the Http request.
+//
+// GET http://localhost:8080/secret
+// and use admin,admin for the credentials
+
+func main() {
+	ws := new(restful.WebService)
+	ws.Route(ws.GET("/secret").Filter(basicAuthenticate).To(secret))
+	restful.Add(ws)
+	http.ListenAndServe(":8080", nil)
+}
+
+func basicAuthenticate(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	encoded := req.Request.Header.Get("Authorization")
+	// usr/pwd = admin/admin
+	// real code does some decoding
+	if len(encoded) == 0 || "Basic YWRtaW46YWRtaW4=" != encoded {
+		resp.AddHeader("WWW-Authenticate", "Basic realm=Protected Area")
+		resp.WriteErrorString(401, "401: Not Authorized")
+		return
+	}
+	chain.ProcessFilter(req, resp)
+}
+
+func secret(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "42")
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-cpuprofiler-service.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-cpuprofiler-service.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"io"
+	"log"
+	"os"
+	"runtime/pprof"
+)
+
+// ProfilingService is a WebService that can start/stop a CPU profile and write results to a file
+// 	GET /{rootPath}/start will activate CPU profiling
+//	GET /{rootPath}/stop will stop profiling
+//
+// NewProfileService("/profiler", "ace.prof").AddWebServiceTo(restful.DefaultContainer)
+//
+type ProfilingService struct {
+	rootPath   string   // the base (root) of the service, e.g. /profiler
+	cpuprofile string   // the output filename to write profile results, e.g. myservice.prof
+	cpufile    *os.File // if not nil, then profiling is active
+}
+
+func NewProfileService(rootPath string, outputFilename string) *ProfilingService {
+	ps := new(ProfilingService)
+	ps.rootPath = rootPath
+	ps.cpuprofile = outputFilename
+	return ps
+}
+
+// Add this ProfileService to a restful Container
+func (p ProfilingService) AddWebServiceTo(container *restful.Container) {
+	ws := new(restful.WebService)
+	ws.Path(p.rootPath).Consumes("*/*").Produces(restful.MIME_JSON)
+	ws.Route(ws.GET("/start").To(p.startProfiler))
+	ws.Route(ws.GET("/stop").To(p.stopProfiler))
+	container.Add(ws)
+}
+
+func (p *ProfilingService) startProfiler(req *restful.Request, resp *restful.Response) {
+	if p.cpufile != nil {
+		io.WriteString(resp.ResponseWriter, "[restful] CPU profiling already running")
+		return // error?
+	}
+	cpufile, err := os.Create(p.cpuprofile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// remember for close
+	p.cpufile = cpufile
+	pprof.StartCPUProfile(cpufile)
+	io.WriteString(resp.ResponseWriter, "[restful] CPU profiling started, writing on:"+p.cpuprofile)
+}
+
+func (p *ProfilingService) stopProfiler(req *restful.Request, resp *restful.Response) {
+	if p.cpufile == nil {
+		io.WriteString(resp.ResponseWriter, "[restful] CPU profiling not active")
+		return // error?
+	}
+	pprof.StopCPUProfile()
+	p.cpufile.Close()
+	p.cpufile = nil
+	io.WriteString(resp.ResponseWriter, "[restful] CPU profiling stopped, closing:"+p.cpuprofile)
+}
+
+func main() {} // exists for example compilation only

--- a/vendor/github.com/emicklei/go-restful/examples/restful-curly-router.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-curly-router.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/emicklei/go-restful"
+)
+
+// This example has the same service definition as restful-user-resource
+// but uses a different router (CurlyRouter) that does not use regular expressions
+//
+// POST http://localhost:8080/users
+// <User><Id>1</Id><Name>Melissa Raspberry</Name></User>
+//
+// GET http://localhost:8080/users/1
+//
+// PUT http://localhost:8080/users/1
+// <User><Id>1</Id><Name>Melissa</Name></User>
+//
+// DELETE http://localhost:8080/users/1
+//
+
+type User struct {
+	Id, Name string
+}
+
+type UserResource struct {
+	// normally one would use DAO (data access object)
+	users map[string]User
+}
+
+func (u UserResource) Register(container *restful.Container) {
+	ws := new(restful.WebService)
+	ws.
+		Path("/users").
+		Consumes(restful.MIME_XML, restful.MIME_JSON).
+		Produces(restful.MIME_JSON, restful.MIME_XML) // you can specify this per route as well
+
+	ws.Route(ws.GET("/{user-id}").To(u.findUser))
+	ws.Route(ws.POST("").To(u.updateUser))
+	ws.Route(ws.PUT("/{user-id}").To(u.createUser))
+	ws.Route(ws.DELETE("/{user-id}").To(u.removeUser))
+
+	container.Add(ws)
+}
+
+// GET http://localhost:8080/users/1
+//
+func (u UserResource) findUser(request *restful.Request, response *restful.Response) {
+	id := request.PathParameter("user-id")
+	usr := u.users[id]
+	if len(usr.Id) == 0 {
+		response.AddHeader("Content-Type", "text/plain")
+		response.WriteErrorString(http.StatusNotFound, "User could not be found.")
+	} else {
+		response.WriteEntity(usr)
+	}
+}
+
+// POST http://localhost:8080/users
+// <User><Id>1</Id><Name>Melissa Raspberry</Name></User>
+//
+func (u *UserResource) updateUser(request *restful.Request, response *restful.Response) {
+	usr := new(User)
+	err := request.ReadEntity(&usr)
+	if err == nil {
+		u.users[usr.Id] = *usr
+		response.WriteEntity(usr)
+	} else {
+		response.AddHeader("Content-Type", "text/plain")
+		response.WriteErrorString(http.StatusInternalServerError, err.Error())
+	}
+}
+
+// PUT http://localhost:8080/users/1
+// <User><Id>1</Id><Name>Melissa</Name></User>
+//
+func (u *UserResource) createUser(request *restful.Request, response *restful.Response) {
+	usr := User{Id: request.PathParameter("user-id")}
+	err := request.ReadEntity(&usr)
+	if err == nil {
+		u.users[usr.Id] = usr
+		response.WriteHeaderAndEntity(http.StatusCreated, usr)
+	} else {
+		response.AddHeader("Content-Type", "text/plain")
+		response.WriteErrorString(http.StatusInternalServerError, err.Error())
+	}
+}
+
+// DELETE http://localhost:8080/users/1
+//
+func (u *UserResource) removeUser(request *restful.Request, response *restful.Response) {
+	id := request.PathParameter("user-id")
+	delete(u.users, id)
+}
+
+func main() {
+	wsContainer := restful.NewContainer()
+	wsContainer.Router(restful.CurlyRouter{})
+	u := UserResource{map[string]User{}}
+	u.Register(wsContainer)
+
+	log.Printf("start listening on localhost:8080")
+	server := &http.Server{Addr: ":8080", Handler: wsContainer}
+	log.Fatal(server.ListenAndServe())
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-encoding-filter.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-encoding-filter.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"log"
+	"net/http"
+)
+
+type User struct {
+	Id, Name string
+}
+
+type UserList struct {
+	Users []User
+}
+
+//
+// This example shows how to use the CompressingResponseWriter by a Filter
+// such that encoding can be enabled per WebService or per Route (instead of per container)
+// Using restful.DefaultContainer.EnableContentEncoding(true) will encode all responses served by WebServices in the DefaultContainer.
+//
+// Set Accept-Encoding to gzip or deflate
+// GET http://localhost:8080/users/42
+// and look at the response headers
+
+func main() {
+	restful.Add(NewUserService())
+	log.Printf("start listening on localhost:8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func NewUserService() *restful.WebService {
+	ws := new(restful.WebService)
+	ws.
+		Path("/users").
+		Consumes(restful.MIME_XML, restful.MIME_JSON).
+		Produces(restful.MIME_JSON, restful.MIME_XML)
+
+	// install a response encoding filter
+	ws.Route(ws.GET("/{user-id}").Filter(encodingFilter).To(findUser))
+	return ws
+}
+
+// Route Filter (defines FilterFunction)
+func encodingFilter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	log.Printf("[encoding-filter] %s,%s\n", req.Request.Method, req.Request.URL)
+	// wrap responseWriter into a compressing one
+	compress, _ := restful.NewCompressingResponseWriter(resp.ResponseWriter, restful.ENCODING_GZIP)
+	resp.ResponseWriter = compress
+	defer func() {
+		compress.Close()
+	}()
+	chain.ProcessFilter(req, resp)
+}
+
+// GET http://localhost:8080/users/42
+//
+func findUser(request *restful.Request, response *restful.Response) {
+	log.Printf("findUser")
+	response.WriteEntity(User{"42", "Gandalf"})
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-filters.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-filters.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"log"
+	"net/http"
+	"time"
+)
+
+type User struct {
+	Id, Name string
+}
+
+type UserList struct {
+	Users []User
+}
+
+// This example show how to create and use the three different Filters (Container,WebService and Route)
+// When applied to the restful.DefaultContainer, we refer to them as a global filter.
+//
+// GET  http://locahost:8080/users/42
+// and see the logging per filter (try repeating this request)
+
+func main() {
+	// install a global (=DefaultContainer) filter (processed before any webservice in the DefaultContainer)
+	restful.Filter(globalLogging)
+
+	restful.Add(NewUserService())
+	log.Printf("start listening on localhost:8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func NewUserService() *restful.WebService {
+	ws := new(restful.WebService)
+	ws.
+		Path("/users").
+		Consumes(restful.MIME_XML, restful.MIME_JSON).
+		Produces(restful.MIME_JSON, restful.MIME_XML)
+
+	// install a webservice filter (processed before any route)
+	ws.Filter(webserviceLogging).Filter(measureTime)
+
+	// install a counter filter
+	ws.Route(ws.GET("").Filter(NewCountFilter().routeCounter).To(getAllUsers))
+
+	// install 2 chained route filters (processed before calling findUser)
+	ws.Route(ws.GET("/{user-id}").Filter(routeLogging).Filter(NewCountFilter().routeCounter).To(findUser))
+	return ws
+}
+
+// Global Filter
+func globalLogging(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	log.Printf("[global-filter (logger)] %s,%s\n", req.Request.Method, req.Request.URL)
+	chain.ProcessFilter(req, resp)
+}
+
+// WebService Filter
+func webserviceLogging(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	log.Printf("[webservice-filter (logger)] %s,%s\n", req.Request.Method, req.Request.URL)
+	chain.ProcessFilter(req, resp)
+}
+
+// WebService (post-process) Filter (as a struct that defines a FilterFunction)
+func measureTime(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	now := time.Now()
+	chain.ProcessFilter(req, resp)
+	log.Printf("[webservice-filter (timer)] %v\n", time.Now().Sub(now))
+}
+
+// Route Filter (defines FilterFunction)
+func routeLogging(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	log.Printf("[route-filter (logger)] %s,%s\n", req.Request.Method, req.Request.URL)
+	chain.ProcessFilter(req, resp)
+}
+
+// Route Filter (as a struct that defines a FilterFunction)
+// CountFilter implements a FilterFunction for counting requests.
+type CountFilter struct {
+	count   int
+	counter chan int // for go-routine safe count increments
+}
+
+// NewCountFilter creates and initializes a new CountFilter.
+func NewCountFilter() *CountFilter {
+	c := new(CountFilter)
+	c.counter = make(chan int)
+	go func() {
+		for {
+			c.count += <-c.counter
+		}
+	}()
+	return c
+}
+
+// routeCounter increments the count of the filter (through a channel)
+func (c *CountFilter) routeCounter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	c.counter <- 1
+	log.Printf("[route-filter (counter)] count:%d", c.count)
+	chain.ProcessFilter(req, resp)
+}
+
+// GET http://localhost:8080/users
+//
+func getAllUsers(request *restful.Request, response *restful.Response) {
+	log.Printf("getAllUsers")
+	response.WriteEntity(UserList{[]User{{"42", "Gandalf"}, {"3.14", "Pi"}}})
+}
+
+// GET http://localhost:8080/users/42
+//
+func findUser(request *restful.Request, response *restful.Response) {
+	log.Printf("findUser")
+	response.WriteEntity(User{"42", "Gandalf"})
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-form-handling.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-form-handling.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"github.com/emicklei/go-restful"
+	"github.com/gorilla/schema"
+	"io"
+	"net/http"
+)
+
+// This example shows how to handle a POST of a HTML form that uses the standard x-www-form-urlencoded content-type.
+// It uses the gorilla web tool kit schema package to decode the form data into a struct.
+//
+// GET http://localhost:8080/profiles
+//
+
+type Profile struct {
+	Name string
+	Age  int
+}
+
+var decoder *schema.Decoder
+
+func main() {
+	decoder = schema.NewDecoder()
+	ws := new(restful.WebService)
+	ws.Route(ws.POST("/profiles").Consumes("application/x-www-form-urlencoded").To(postAdddress))
+	ws.Route(ws.GET("/profiles").To(addresssForm))
+	restful.Add(ws)
+	http.ListenAndServe(":8080", nil)
+}
+
+func postAdddress(req *restful.Request, resp *restful.Response) {
+	err := req.Request.ParseForm()
+	if err != nil {
+		resp.WriteErrorString(http.StatusBadRequest, err.Error())
+		return
+	}
+	p := new(Profile)
+	err = decoder.Decode(p, req.Request.PostForm)
+	if err != nil {
+		resp.WriteErrorString(http.StatusBadRequest, err.Error())
+		return
+	}
+	io.WriteString(resp.ResponseWriter, fmt.Sprintf("<html><body>Name=%s, Age=%d</body></html>", p.Name, p.Age))
+}
+
+func addresssForm(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp.ResponseWriter,
+		`<html>
+		<body>
+		<h1>Enter Profile</h1>
+		<form method="post">
+		    <label>Name:</label>
+			<input type="text" name="Name"/>
+			<label>Age:</label>
+		    <input type="text" name="Age"/>
+			<input type="Submit" />
+		</form>
+		</body>
+		</html>`)
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-hello-world.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-hello-world.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"io"
+	"net/http"
+)
+
+// This example shows the minimal code needed to get a restful.WebService working.
+//
+// GET http://localhost:8080/hello
+
+func main() {
+	ws := new(restful.WebService)
+	ws.Route(ws.GET("/hello").To(hello))
+	restful.Add(ws)
+	http.ListenAndServe(":8080", nil)
+}
+
+func hello(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "world")
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-html-template.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-html-template.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"text/template"
+
+	"github.com/emicklei/go-restful"
+)
+
+// This example shows how to serve a HTML page using the standard Go template engine.
+//
+// GET http://localhost:8080/
+
+func main() {
+	ws := new(restful.WebService)
+	ws.Route(ws.GET("/").To(home))
+	restful.Add(ws)
+	print("open browser on http://localhost:8080/\n")
+	http.ListenAndServe(":8080", nil)
+}
+
+type Message struct {
+	Text string
+}
+
+func home(req *restful.Request, resp *restful.Response) {
+	p := &Message{"restful-html-template demo"}
+	// you might want to cache compiled templates
+	t, err := template.ParseFiles("home.html")
+	if err != nil {
+		log.Fatalf("Template gave: %s", err)
+	}
+	t.Execute(resp.ResponseWriter, p)
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-multi-containers.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-multi-containers.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"io"
+	"log"
+	"net/http"
+)
+
+// This example shows how to have a program with 2 WebServices containers
+// each having a http server listening on its own port.
+//
+// The first "hello" is added to the restful.DefaultContainer (and uses DefaultServeMux)
+// For the second "hello", a new container and ServeMux is created
+// and requires a new http.Server with the container being the Handler.
+// This first server is spawn in its own go-routine such that the program proceeds to create the second.
+//
+// GET http://localhost:8080/hello
+// GET http://localhost:8081/hello
+
+func main() {
+	ws := new(restful.WebService)
+	ws.Route(ws.GET("/hello").To(hello))
+	restful.Add(ws)
+	go func() {
+		http.ListenAndServe(":8080", nil)
+	}()
+
+	container2 := restful.NewContainer()
+	ws2 := new(restful.WebService)
+	ws2.Route(ws2.GET("/hello").To(hello2))
+	container2.Add(ws2)
+	server := &http.Server{Addr: ":8081", Handler: container2}
+	log.Fatal(server.ListenAndServe())
+}
+
+func hello(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "default world")
+}
+
+func hello2(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "second world")
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-no-cache-filter.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-no-cache-filter.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/emicklei/go-restful"
+)
+
+// This example shows how to use a WebService filter that passed the Http headers to disable browser cacheing.
+//
+// GET http://localhost:8080/hello
+
+func main() {
+	ws := new(restful.WebService)
+	ws.Filter(restful.NoBrowserCacheFilter)
+	ws.Route(ws.GET("/hello").To(hello))
+	restful.Add(ws)
+	http.ListenAndServe(":8080", nil)
+}
+
+func hello(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "world")
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-options-filter.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-options-filter.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"io"
+	"log"
+	"net/http"
+)
+
+// This example shows how to use the OPTIONSFilter on a Container
+//
+// OPTIONS http://localhost:8080/users
+//
+// OPTIONS http://localhost:8080/users/1
+
+type UserResource struct{}
+
+func (u UserResource) RegisterTo(container *restful.Container) {
+	ws := new(restful.WebService)
+	ws.
+		Path("/users").
+		Consumes("*/*").
+		Produces("*/*")
+
+	ws.Route(ws.GET("/{user-id}").To(u.nop))
+	ws.Route(ws.POST("").To(u.nop))
+	ws.Route(ws.PUT("/{user-id}").To(u.nop))
+	ws.Route(ws.DELETE("/{user-id}").To(u.nop))
+
+	container.Add(ws)
+}
+
+func (u UserResource) nop(request *restful.Request, response *restful.Response) {
+	io.WriteString(response.ResponseWriter, "this would be a normal response")
+}
+
+func main() {
+	wsContainer := restful.NewContainer()
+	u := UserResource{}
+	u.RegisterTo(wsContainer)
+
+	// Add container filter to respond to OPTIONS
+	wsContainer.Filter(wsContainer.OPTIONSFilter)
+
+	// For use on the default container, you can write
+	// restful.Filter(restful.OPTIONSFilter())
+
+	log.Printf("start listening on localhost:8080")
+	server := &http.Server{Addr: ":8080", Handler: wsContainer}
+	log.Fatal(server.ListenAndServe())
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-path-tail.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-path-tail.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	. "github.com/emicklei/go-restful"
+	"io"
+	"net/http"
+)
+
+// This example shows how to a Route that matches the "tail" of a path.
+// Requires the use of a CurlyRouter and the star "*" path parameter pattern.
+//
+// GET http://localhost:8080/basepath/some/other/location/test.xml
+
+func main() {
+	DefaultContainer.Router(CurlyRouter{})
+	ws := new(WebService)
+	ws.Route(ws.GET("/basepath/{resource:*}").To(staticFromPathParam))
+	Add(ws)
+
+	println("[go-restful] serve path tails from http://localhost:8080/basepath")
+	http.ListenAndServe(":8080", nil)
+}
+
+func staticFromPathParam(req *Request, resp *Response) {
+	io.WriteString(resp, "Tail="+req.PathParameter("resource"))
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-pre-post-filters.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-pre-post-filters.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"io"
+	"log"
+	"net/http"
+)
+
+// This example shows how the different types of filters are called in the request-response flow.
+// The call chain is logged on the console when sending an http request.
+//
+// GET http://localhost:8080/1
+// GET http://localhost:8080/2
+
+var indentLevel int
+
+func container_filter_A(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	log.Printf("url path:%v\n", req.Request.URL)
+	trace("container_filter_A: before", 1)
+	chain.ProcessFilter(req, resp)
+	trace("container_filter_A: after", -1)
+}
+
+func container_filter_B(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	trace("container_filter_B: before", 1)
+	chain.ProcessFilter(req, resp)
+	trace("container_filter_B: after", -1)
+}
+
+func service_filter_A(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	trace("service_filter_A: before", 1)
+	chain.ProcessFilter(req, resp)
+	trace("service_filter_A: after", -1)
+}
+
+func service_filter_B(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	trace("service_filter_B: before", 1)
+	chain.ProcessFilter(req, resp)
+	trace("service_filter_B: after", -1)
+}
+
+func route_filter_A(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	trace("route_filter_A: before", 1)
+	chain.ProcessFilter(req, resp)
+	trace("route_filter_A: after", -1)
+}
+
+func route_filter_B(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	trace("route_filter_B: before", 1)
+	chain.ProcessFilter(req, resp)
+	trace("route_filter_B: after", -1)
+}
+
+func trace(what string, delta int) {
+	indented := what
+	if delta < 0 {
+		indentLevel += delta
+	}
+	for t := 0; t < indentLevel; t++ {
+		indented = "." + indented
+	}
+	log.Printf("%s", indented)
+	if delta > 0 {
+		indentLevel += delta
+	}
+}
+
+func main() {
+	restful.Filter(container_filter_A)
+	restful.Filter(container_filter_B)
+
+	ws1 := new(restful.WebService)
+	ws1.Path("/1")
+	ws1.Filter(service_filter_A)
+	ws1.Filter(service_filter_B)
+	ws1.Route(ws1.GET("").To(doit1).Filter(route_filter_A).Filter(route_filter_B))
+
+	ws2 := new(restful.WebService)
+	ws2.Path("/2")
+	ws2.Filter(service_filter_A)
+	ws2.Filter(service_filter_B)
+	ws2.Route(ws2.GET("").To(doit2).Filter(route_filter_A).Filter(route_filter_B))
+
+	restful.Add(ws1)
+	restful.Add(ws2)
+
+	log.Print("go-restful example listing on http://localhost:8080/1 and http://localhost:8080/2")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func doit1(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "nothing to see in 1")
+}
+
+func doit2(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "nothing to see in 2")
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-resource-functions.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-resource-functions.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	"log"
+	"net/http"
+)
+
+// This example shows how to use methods as RouteFunctions for WebServices.
+// The ProductResource has a Register() method that creates and initializes
+// a WebService to expose its methods as REST operations.
+// The WebService is added to the restful.DefaultContainer.
+// A ProductResource is typically created using some data access object.
+//
+// GET http://localhost:8080/products/1
+// POST http://localhost:8080/products
+// <Product><Id>1</Id><Title>The First</Title></Product>
+
+type Product struct {
+	Id, Title string
+}
+
+type ProductResource struct {
+	// typically reference a DAO (data-access-object)
+}
+
+func (p ProductResource) getOne(req *restful.Request, resp *restful.Response) {
+	id := req.PathParameter("id")
+	log.Println("getting product with id:" + id)
+	resp.WriteEntity(Product{Id: id, Title: "test"})
+}
+
+func (p ProductResource) postOne(req *restful.Request, resp *restful.Response) {
+	updatedProduct := new(Product)
+	err := req.ReadEntity(updatedProduct)
+	if err != nil { // bad request
+		resp.WriteErrorString(http.StatusBadRequest, err.Error())
+		return
+	}
+	log.Println("updating product with id:" + updatedProduct.Id)
+}
+
+func (p ProductResource) Register() {
+	ws := new(restful.WebService)
+	ws.Path("/products")
+	ws.Consumes(restful.MIME_XML)
+	ws.Produces(restful.MIME_XML)
+
+	ws.Route(ws.GET("/{id}").To(p.getOne).
+		Doc("get the product by its id").
+		Param(ws.PathParameter("id", "identifier of the product").DataType("string")))
+
+	ws.Route(ws.POST("").To(p.postOne).
+		Doc("update or create a product").
+		Param(ws.BodyParameter("Product", "a Product (XML)").DataType("main.Product")))
+
+	restful.Add(ws)
+}
+
+func main() {
+	ProductResource{}.Register()
+	http.ListenAndServe(":8080", nil)
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-serve-static.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-serve-static.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+
+	"github.com/emicklei/go-restful"
+)
+
+// This example shows how to define methods that serve static files
+// It uses the standard http.ServeFile method
+//
+// GET http://localhost:8080/static/test.xml
+// GET http://localhost:8080/static/
+//
+// GET http://localhost:8080/static?resource=subdir/test.xml
+
+var rootdir = "/tmp"
+
+func main() {
+	restful.DefaultContainer.Router(restful.CurlyRouter{})
+
+	ws := new(restful.WebService)
+	ws.Route(ws.GET("/static/{subpath:*}").To(staticFromPathParam))
+	ws.Route(ws.GET("/static").To(staticFromQueryParam))
+	restful.Add(ws)
+
+	println("[go-restful] serving files on http://localhost:8080/static from local /tmp")
+	http.ListenAndServe(":8080", nil)
+}
+
+func staticFromPathParam(req *restful.Request, resp *restful.Response) {
+	actual := path.Join(rootdir, req.PathParameter("subpath"))
+	fmt.Printf("serving %s ... (from %s)\n", actual, req.PathParameter("subpath"))
+	http.ServeFile(
+		resp.ResponseWriter,
+		req.Request,
+		actual)
+}
+
+func staticFromQueryParam(req *restful.Request, resp *restful.Response) {
+	http.ServeFile(
+		resp.ResponseWriter,
+		req.Request,
+		path.Join(rootdir, req.QueryParameter("resource")))
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-swagger.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-swagger.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/swagger"
+)
+
+type Book struct {
+	Title  string
+	Author string
+}
+
+func main() {
+	ws := new(restful.WebService)
+	ws.Path("/books")
+	ws.Consumes(restful.MIME_JSON, restful.MIME_XML)
+	ws.Produces(restful.MIME_JSON, restful.MIME_XML)
+	restful.Add(ws)
+
+	ws.Route(ws.GET("/{medium}").To(noop).
+		Doc("Search all books").
+		Param(ws.PathParameter("medium", "digital or paperback").DataType("string")).
+		Param(ws.QueryParameter("language", "en,nl,de").DataType("string")).
+		Param(ws.HeaderParameter("If-Modified-Since", "last known timestamp").DataType("datetime")).
+		Do(returns200, returns500))
+
+	ws.Route(ws.PUT("/{medium}").To(noop).
+		Doc("Add a new book").
+		Param(ws.PathParameter("medium", "digital or paperback").DataType("string")).
+		Reads(Book{}))
+
+	// You can install the Swagger Service which provides a nice Web UI on your REST API
+	// You need to download the Swagger HTML5 assets and change the FilePath location in the config below.
+	// Open http://localhost:8080/apidocs and enter http://localhost:8080/apidocs.json in the api input field.
+	config := swagger.Config{
+		WebServices:    restful.DefaultContainer.RegisteredWebServices(), // you control what services are visible
+		WebServicesUrl: "http://localhost:8080",
+		ApiPath:        "/apidocs.json",
+
+		// Optionally, specifiy where the UI is located
+		SwaggerPath:     "/apidocs/",
+		SwaggerFilePath: "/Users/emicklei/xProjects/swagger-ui/dist"}
+	swagger.RegisterSwaggerService(config, restful.DefaultContainer)
+
+	log.Printf("start listening on localhost:8080")
+	server := &http.Server{Addr: ":8080", Handler: restful.DefaultContainer}
+	log.Fatal(server.ListenAndServe())
+}
+
+func noop(req *restful.Request, resp *restful.Response) {}
+
+func returns200(b *restful.RouteBuilder) {
+	b.Returns(http.StatusOK, "OK", Book{})
+}
+
+func returns500(b *restful.RouteBuilder) {
+	b.Returns(http.StatusInternalServerError, "Bummer, something went wrong", nil)
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-user-resource.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-user-resource.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/swagger"
+)
+
+// This example show a complete (GET,PUT,POST,DELETE) conventional example of
+// a REST Resource including documentation to be served by e.g. a Swagger UI
+// It is recommended to create a Resource struct (UserResource) that can encapsulate
+// an object that provide domain access (a DAO)
+// It has a Register method including the complete Route mapping to methods together
+// with all the appropriate documentation
+//
+// POST http://localhost:8080/users
+// <User><Id>1</Id><Name>Melissa Raspberry</Name></User>
+//
+// GET http://localhost:8080/users/1
+//
+// PUT http://localhost:8080/users/1
+// <User><Id>1</Id><Name>Melissa</Name></User>
+//
+// DELETE http://localhost:8080/users/1
+//
+
+type User struct {
+	Id, Name string
+}
+
+type UserResource struct {
+	// normally one would use DAO (data access object)
+	users map[string]User
+}
+
+func (u UserResource) Register(container *restful.Container) {
+	ws := new(restful.WebService)
+	ws.
+		Path("/users").
+		Doc("Manage Users").
+		Consumes(restful.MIME_XML, restful.MIME_JSON).
+		Produces(restful.MIME_JSON, restful.MIME_XML) // you can specify this per route as well
+
+	ws.Route(ws.GET("/{user-id}").To(u.findUser).
+		// docs
+		Doc("get a user").
+		Operation("findUser").
+		Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")).
+		Writes(User{})) // on the response
+
+	ws.Route(ws.PUT("/{user-id}").To(u.updateUser).
+		// docs
+		Doc("update a user").
+		Operation("updateUser").
+		Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")).
+		ReturnsError(409, "duplicate user-id", nil).
+		Reads(User{})) // from the request
+
+	ws.Route(ws.POST("").To(u.createUser).
+		// docs
+		Doc("create a user").
+		Operation("createUser").
+		Reads(User{})) // from the request
+
+	ws.Route(ws.DELETE("/{user-id}").To(u.removeUser).
+		// docs
+		Doc("delete a user").
+		Operation("removeUser").
+		Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")))
+
+	container.Add(ws)
+}
+
+// GET http://localhost:8080/users/1
+//
+func (u UserResource) findUser(request *restful.Request, response *restful.Response) {
+	id := request.PathParameter("user-id")
+	usr := u.users[id]
+	if len(usr.Id) == 0 {
+		response.AddHeader("Content-Type", "text/plain")
+		response.WriteErrorString(http.StatusNotFound, "404: User could not be found.")
+		return
+	}
+	response.WriteEntity(usr)
+}
+
+// POST http://localhost:8080/users
+// <User><Name>Melissa</Name></User>
+//
+func (u *UserResource) createUser(request *restful.Request, response *restful.Response) {
+	usr := new(User)
+	err := request.ReadEntity(usr)
+	if err != nil {
+		response.AddHeader("Content-Type", "text/plain")
+		response.WriteErrorString(http.StatusInternalServerError, err.Error())
+		return
+	}
+	usr.Id = strconv.Itoa(len(u.users) + 1) // simple id generation
+	u.users[usr.Id] = *usr
+	response.WriteHeaderAndEntity(http.StatusCreated, usr)
+}
+
+// PUT http://localhost:8080/users/1
+// <User><Id>1</Id><Name>Melissa Raspberry</Name></User>
+//
+func (u *UserResource) updateUser(request *restful.Request, response *restful.Response) {
+	usr := new(User)
+	err := request.ReadEntity(&usr)
+	if err != nil {
+		response.AddHeader("Content-Type", "text/plain")
+		response.WriteErrorString(http.StatusInternalServerError, err.Error())
+		return
+	}
+	u.users[usr.Id] = *usr
+	response.WriteEntity(usr)
+}
+
+// DELETE http://localhost:8080/users/1
+//
+func (u *UserResource) removeUser(request *restful.Request, response *restful.Response) {
+	id := request.PathParameter("user-id")
+	delete(u.users, id)
+}
+
+func main() {
+	// to see what happens in the package, uncomment the following
+	//restful.TraceLogger(log.New(os.Stdout, "[restful] ", log.LstdFlags|log.Lshortfile))
+
+	wsContainer := restful.NewContainer()
+	u := UserResource{map[string]User{}}
+	u.Register(wsContainer)
+
+	// Optionally, you can install the Swagger Service which provides a nice Web UI on your REST API
+	// You need to download the Swagger HTML5 assets and change the FilePath location in the config below.
+	// Open http://localhost:8080/apidocs and enter http://localhost:8080/apidocs.json in the api input field.
+	config := swagger.Config{
+		WebServices:    wsContainer.RegisteredWebServices(), // you control what services are visible
+		WebServicesUrl: "http://localhost:8080",
+		ApiPath:        "/apidocs.json",
+
+		// Optionally, specifiy where the UI is located
+		SwaggerPath:     "/apidocs/",
+		SwaggerFilePath: "/Users/emicklei/xProjects/swagger-ui/dist"}
+	swagger.RegisterSwaggerService(config, wsContainer)
+
+	log.Printf("start listening on localhost:8080")
+	server := &http.Server{Addr: ":8080", Handler: wsContainer}
+	log.Fatal(server.ListenAndServe())
+}

--- a/vendor/github.com/emicklei/go-restful/examples/restful-user-service.go
+++ b/vendor/github.com/emicklei/go-restful/examples/restful-user-service.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful/swagger"
+)
+
+// This example is functionally the same as the example in restful-user-resource.go
+// with the only difference that is served using the restful.DefaultContainer
+
+type User struct {
+	Id, Name string
+}
+
+type UserService struct {
+	// normally one would use DAO (data access object)
+	users map[string]User
+}
+
+func (u UserService) Register() {
+	ws := new(restful.WebService)
+	ws.
+		Path("/users").
+		Consumes(restful.MIME_XML, restful.MIME_JSON).
+		Produces(restful.MIME_JSON, restful.MIME_XML) // you can specify this per route as well
+
+	ws.Route(ws.GET("/").To(u.findAllUsers).
+		// docs
+		Doc("get all users").
+		Operation("findAllUsers").
+		Returns(200, "OK", []User{}))
+
+	ws.Route(ws.GET("/{user-id}").To(u.findUser).
+		// docs
+		Doc("get a user").
+		Operation("findUser").
+		Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")).
+		Writes(User{})) // on the response
+
+	ws.Route(ws.PUT("/{user-id}").To(u.updateUser).
+		// docs
+		Doc("update a user").
+		Operation("updateUser").
+		Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")).
+		Reads(User{})) // from the request
+
+	ws.Route(ws.PUT("").To(u.createUser).
+		// docs
+		Doc("create a user").
+		Operation("createUser").
+		Reads(User{})) // from the request
+
+	ws.Route(ws.DELETE("/{user-id}").To(u.removeUser).
+		// docs
+		Doc("delete a user").
+		Operation("removeUser").
+		Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")))
+
+	restful.Add(ws)
+}
+
+// GET http://localhost:8080/users
+//
+func (u UserService) findAllUsers(request *restful.Request, response *restful.Response) {
+	response.WriteEntity(u.users)
+}
+
+// GET http://localhost:8080/users/1
+//
+func (u UserService) findUser(request *restful.Request, response *restful.Response) {
+	id := request.PathParameter("user-id")
+	usr := u.users[id]
+	if len(usr.Id) == 0 {
+		response.WriteErrorString(http.StatusNotFound, "User could not be found.")
+	} else {
+		response.WriteEntity(usr)
+	}
+}
+
+// PUT http://localhost:8080/users/1
+// <User><Id>1</Id><Name>Melissa Raspberry</Name></User>
+//
+func (u *UserService) updateUser(request *restful.Request, response *restful.Response) {
+	usr := new(User)
+	err := request.ReadEntity(&usr)
+	if err == nil {
+		u.users[usr.Id] = *usr
+		response.WriteEntity(usr)
+	} else {
+		response.WriteError(http.StatusInternalServerError, err)
+	}
+}
+
+// PUT http://localhost:8080/users/1
+// <User><Id>1</Id><Name>Melissa</Name></User>
+//
+func (u *UserService) createUser(request *restful.Request, response *restful.Response) {
+	usr := User{Id: request.PathParameter("user-id")}
+	err := request.ReadEntity(&usr)
+	if err == nil {
+		u.users[usr.Id] = usr
+		response.WriteHeaderAndEntity(http.StatusCreated, usr)
+	} else {
+		response.WriteError(http.StatusInternalServerError, err)
+	}
+}
+
+// DELETE http://localhost:8080/users/1
+//
+func (u *UserService) removeUser(request *restful.Request, response *restful.Response) {
+	id := request.PathParameter("user-id")
+	delete(u.users, id)
+}
+
+func main() {
+	u := UserService{map[string]User{}}
+	u.Register()
+
+	// Optionally, you can install the Swagger Service which provides a nice Web UI on your REST API
+	// You need to download the Swagger HTML5 assets and change the FilePath location in the config below.
+	// Open http://localhost:8080/apidocs and enter http://localhost:8080/apidocs.json in the api input field.
+	config := swagger.Config{
+		WebServices:    restful.RegisteredWebServices(), // you control what services are visible
+		WebServicesUrl: "http://localhost:8080",
+		ApiPath:        "/apidocs.json",
+
+		// Optionally, specifiy where the UI is located
+		SwaggerPath:     "/apidocs/",
+		SwaggerFilePath: "/Users/emicklei/Projects/swagger-ui/dist"}
+	swagger.InstallSwaggerService(config)
+
+	log.Printf("start listening on localhost:8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/vendor/github.com/emicklei/go-restful/filter.go
+++ b/vendor/github.com/emicklei/go-restful/filter.go
@@ -1,0 +1,35 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+// FilterChain is a request scoped object to process one or more filters before calling the target RouteFunction.
+type FilterChain struct {
+	Filters []FilterFunction // ordered list of FilterFunction
+	Index   int              // index into filters that is currently in progress
+	Target  RouteFunction    // function to call after passing all filters
+}
+
+// ProcessFilter passes the request,response pair through the next of Filters.
+// Each filter can decide to proceed to the next Filter or handle the Response itself.
+func (f *FilterChain) ProcessFilter(request *Request, response *Response) {
+	if f.Index < len(f.Filters) {
+		f.Index++
+		f.Filters[f.Index-1](request, response, f)
+	} else {
+		f.Target(request, response)
+	}
+}
+
+// FilterFunction definitions must call ProcessFilter on the FilterChain to pass on the control and eventually call the RouteFunction
+type FilterFunction func(*Request, *Response, *FilterChain)
+
+// NoBrowserCacheFilter is a filter function to set HTTP headers that disable browser caching
+// See examples/restful-no-cache-filter.go for usage
+func NoBrowserCacheFilter(req *Request, resp *Response, chain *FilterChain) {
+	resp.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate") // HTTP 1.1.
+	resp.Header().Set("Pragma", "no-cache")                                   // HTTP 1.0.
+	resp.Header().Set("Expires", "0")                                         // Proxies.
+	chain.ProcessFilter(req, resp)
+}

--- a/vendor/github.com/emicklei/go-restful/jsr311.go
+++ b/vendor/github.com/emicklei/go-restful/jsr311.go
@@ -1,0 +1,248 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+)
+
+// RouterJSR311 implements the flow for matching Requests to Routes (and consequently Resource Functions)
+// as specified by the JSR311 http://jsr311.java.net/nonav/releases/1.1/spec/spec.html.
+// RouterJSR311 implements the Router interface.
+// Concept of locators is not implemented.
+type RouterJSR311 struct{}
+
+// SelectRoute is part of the Router interface and returns the best match
+// for the WebService and its Route for the given Request.
+func (r RouterJSR311) SelectRoute(
+	webServices []*WebService,
+	httpRequest *http.Request) (selectedService *WebService, selectedRoute *Route, err error) {
+
+	// Identify the root resource class (WebService)
+	dispatcher, finalMatch, err := r.detectDispatcher(httpRequest.URL.Path, webServices)
+	if err != nil {
+		return nil, nil, NewError(http.StatusNotFound, "")
+	}
+	// Obtain the set of candidate methods (Routes)
+	routes := r.selectRoutes(dispatcher, finalMatch)
+	if len(routes) == 0 {
+		return dispatcher, nil, NewError(http.StatusNotFound, "404: Page Not Found")
+	}
+
+	// Identify the method (Route) that will handle the request
+	route, ok := r.detectRoute(routes, httpRequest)
+	return dispatcher, route, ok
+}
+
+// http://jsr311.java.net/nonav/releases/1.1/spec/spec3.html#x3-360003.7.2
+func (r RouterJSR311) detectRoute(routes []Route, httpRequest *http.Request) (*Route, error) {
+	// http method
+	methodOk := []Route{}
+	for _, each := range routes {
+		if httpRequest.Method == each.Method {
+			methodOk = append(methodOk, each)
+		}
+	}
+	if len(methodOk) == 0 {
+		if trace {
+			traceLogger.Printf("no Route found (in %d routes) that matches HTTP method %s\n", len(routes), httpRequest.Method)
+		}
+		return nil, NewError(http.StatusMethodNotAllowed, "405: Method Not Allowed")
+	}
+	inputMediaOk := methodOk
+
+	// content-type
+	contentType := httpRequest.Header.Get(HEADER_ContentType)
+	inputMediaOk = []Route{}
+	for _, each := range methodOk {
+		if each.matchesContentType(contentType) {
+			inputMediaOk = append(inputMediaOk, each)
+		}
+	}
+	if len(inputMediaOk) == 0 {
+		if trace {
+			traceLogger.Printf("no Route found (from %d) that matches HTTP Content-Type: %s\n", len(methodOk), contentType)
+		}
+		return nil, NewError(http.StatusUnsupportedMediaType, "415: Unsupported Media Type")
+	}
+
+	// accept
+	outputMediaOk := []Route{}
+	accept := httpRequest.Header.Get(HEADER_Accept)
+	if len(accept) == 0 {
+		accept = "*/*"
+	}
+	for _, each := range inputMediaOk {
+		if each.matchesAccept(accept) {
+			outputMediaOk = append(outputMediaOk, each)
+		}
+	}
+	if len(outputMediaOk) == 0 {
+		if trace {
+			traceLogger.Printf("no Route found (from %d) that matches HTTP Accept: %s\n", len(inputMediaOk), accept)
+		}
+		return nil, NewError(http.StatusNotAcceptable, "406: Not Acceptable")
+	}
+	// return r.bestMatchByMedia(outputMediaOk, contentType, accept), nil
+	return &outputMediaOk[0], nil
+}
+
+// http://jsr311.java.net/nonav/releases/1.1/spec/spec3.html#x3-360003.7.2
+// n/m > n/* > */*
+func (r RouterJSR311) bestMatchByMedia(routes []Route, contentType string, accept string) *Route {
+	// TODO
+	return &routes[0]
+}
+
+// http://jsr311.java.net/nonav/releases/1.1/spec/spec3.html#x3-360003.7.2  (step 2)
+func (r RouterJSR311) selectRoutes(dispatcher *WebService, pathRemainder string) []Route {
+	filtered := &sortableRouteCandidates{}
+	for _, each := range dispatcher.Routes() {
+		pathExpr := each.pathExpr
+		matches := pathExpr.Matcher.FindStringSubmatch(pathRemainder)
+		if matches != nil {
+			lastMatch := matches[len(matches)-1]
+			if len(lastMatch) == 0 || lastMatch == "/" { // do not include if value is neither empty nor ‘/’.
+				filtered.candidates = append(filtered.candidates,
+					routeCandidate{each, len(matches) - 1, pathExpr.LiteralCount, pathExpr.VarCount})
+			}
+		}
+	}
+	if len(filtered.candidates) == 0 {
+		if trace {
+			traceLogger.Printf("WebService on path %s has no routes that match URL path remainder:%s\n", dispatcher.rootPath, pathRemainder)
+		}
+		return []Route{}
+	}
+	sort.Sort(sort.Reverse(filtered))
+
+	// select other routes from candidates whoes expression matches rmatch
+	matchingRoutes := []Route{filtered.candidates[0].route}
+	for c := 1; c < len(filtered.candidates); c++ {
+		each := filtered.candidates[c]
+		if each.route.pathExpr.Matcher.MatchString(pathRemainder) {
+			matchingRoutes = append(matchingRoutes, each.route)
+		}
+	}
+	return matchingRoutes
+}
+
+// http://jsr311.java.net/nonav/releases/1.1/spec/spec3.html#x3-360003.7.2 (step 1)
+func (r RouterJSR311) detectDispatcher(requestPath string, dispatchers []*WebService) (*WebService, string, error) {
+	filtered := &sortableDispatcherCandidates{}
+	for _, each := range dispatchers {
+		matches := each.pathExpr.Matcher.FindStringSubmatch(requestPath)
+		if matches != nil {
+			filtered.candidates = append(filtered.candidates,
+				dispatcherCandidate{each, matches[len(matches)-1], len(matches), each.pathExpr.LiteralCount, each.pathExpr.VarCount})
+		}
+	}
+	if len(filtered.candidates) == 0 {
+		if trace {
+			traceLogger.Printf("no WebService was found to match URL path:%s\n", requestPath)
+		}
+		return nil, "", errors.New("not found")
+	}
+	sort.Sort(sort.Reverse(filtered))
+	return filtered.candidates[0].dispatcher, filtered.candidates[0].finalMatch, nil
+}
+
+// Types and functions to support the sorting of Routes
+
+type routeCandidate struct {
+	route           Route
+	matchesCount    int // the number of capturing groups
+	literalCount    int // the number of literal characters (means those not resulting from template variable substitution)
+	nonDefaultCount int // the number of capturing groups with non-default regular expressions (i.e. not ‘([^  /]+?)’)
+}
+
+func (r routeCandidate) expressionToMatch() string {
+	return r.route.pathExpr.Source
+}
+
+func (r routeCandidate) String() string {
+	return fmt.Sprintf("(m=%d,l=%d,n=%d)", r.matchesCount, r.literalCount, r.nonDefaultCount)
+}
+
+type sortableRouteCandidates struct {
+	candidates []routeCandidate
+}
+
+func (rcs *sortableRouteCandidates) Len() int {
+	return len(rcs.candidates)
+}
+func (rcs *sortableRouteCandidates) Swap(i, j int) {
+	rcs.candidates[i], rcs.candidates[j] = rcs.candidates[j], rcs.candidates[i]
+}
+func (rcs *sortableRouteCandidates) Less(i, j int) bool {
+	ci := rcs.candidates[i]
+	cj := rcs.candidates[j]
+	// primary key
+	if ci.literalCount < cj.literalCount {
+		return true
+	}
+	if ci.literalCount > cj.literalCount {
+		return false
+	}
+	// secundary key
+	if ci.matchesCount < cj.matchesCount {
+		return true
+	}
+	if ci.matchesCount > cj.matchesCount {
+		return false
+	}
+	// tertiary key
+	if ci.nonDefaultCount < cj.nonDefaultCount {
+		return true
+	}
+	if ci.nonDefaultCount > cj.nonDefaultCount {
+		return false
+	}
+	// quaternary key ("source" is interpreted as Path)
+	return ci.route.Path < cj.route.Path
+}
+
+// Types and functions to support the sorting of Dispatchers
+
+type dispatcherCandidate struct {
+	dispatcher      *WebService
+	finalMatch      string
+	matchesCount    int // the number of capturing groups
+	literalCount    int // the number of literal characters (means those not resulting from template variable substitution)
+	nonDefaultCount int // the number of capturing groups with non-default regular expressions (i.e. not ‘([^  /]+?)’)
+}
+type sortableDispatcherCandidates struct {
+	candidates []dispatcherCandidate
+}
+
+func (dc *sortableDispatcherCandidates) Len() int {
+	return len(dc.candidates)
+}
+func (dc *sortableDispatcherCandidates) Swap(i, j int) {
+	dc.candidates[i], dc.candidates[j] = dc.candidates[j], dc.candidates[i]
+}
+func (dc *sortableDispatcherCandidates) Less(i, j int) bool {
+	ci := dc.candidates[i]
+	cj := dc.candidates[j]
+	// primary key
+	if ci.matchesCount < cj.matchesCount {
+		return true
+	}
+	if ci.matchesCount > cj.matchesCount {
+		return false
+	}
+	// secundary key
+	if ci.literalCount < cj.literalCount {
+		return true
+	}
+	if ci.literalCount > cj.literalCount {
+		return false
+	}
+	// tertiary key
+	return ci.nonDefaultCount < cj.nonDefaultCount
+}

--- a/vendor/github.com/emicklei/go-restful/log/log.go
+++ b/vendor/github.com/emicklei/go-restful/log/log.go
@@ -1,0 +1,31 @@
+package log
+
+import (
+	stdlog "log"
+	"os"
+)
+
+// Logger corresponds to a minimal subset of the interface satisfied by stdlib log.Logger
+type StdLogger interface {
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+}
+
+var Logger StdLogger
+
+func init() {
+	// default Logger
+	SetLogger(stdlog.New(os.Stderr, "[restful] ", stdlog.LstdFlags|stdlog.Lshortfile))
+}
+
+func SetLogger(customLogger StdLogger) {
+	Logger = customLogger
+}
+
+func Print(v ...interface{}) {
+	Logger.Print(v...)
+}
+
+func Printf(format string, v ...interface{}) {
+	Logger.Printf(format, v...)
+}

--- a/vendor/github.com/emicklei/go-restful/logger.go
+++ b/vendor/github.com/emicklei/go-restful/logger.go
@@ -1,0 +1,32 @@
+package restful
+
+// Copyright 2014 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+import (
+	"github.com/emicklei/go-restful/log"
+)
+
+var trace bool = false
+var traceLogger log.StdLogger
+
+func init() {
+	traceLogger = log.Logger // use the package logger by default
+}
+
+// TraceLogger enables detailed logging of Http request matching and filter invocation. Default no logger is set.
+// You may call EnableTracing() directly to enable trace logging to the package-wide logger.
+func TraceLogger(logger log.StdLogger) {
+	traceLogger = logger
+	EnableTracing(logger != nil)
+}
+
+// expose the setter for the global logger on the top-level package
+func SetLogger(customLogger log.StdLogger) {
+	log.SetLogger(customLogger)
+}
+
+// EnableTracing can be used to Trace logging on and off.
+func EnableTracing(enabled bool) {
+	trace = enabled
+}

--- a/vendor/github.com/emicklei/go-restful/mime.go
+++ b/vendor/github.com/emicklei/go-restful/mime.go
@@ -1,0 +1,45 @@
+package restful
+
+import (
+	"strconv"
+	"strings"
+)
+
+type mime struct {
+	media   string
+	quality float64
+}
+
+// insertMime adds a mime to a list and keeps it sorted by quality.
+func insertMime(l []mime, e mime) []mime {
+	for i, each := range l {
+		// if current mime has lower quality then insert before
+		if e.quality > each.quality {
+			left := append([]mime{}, l[0:i]...)
+			return append(append(left, e), l[i:]...)
+		}
+	}
+	return append(l, e)
+}
+
+// sortedMimes returns a list of mime sorted (desc) by its specified quality.
+func sortedMimes(accept string) (sorted []mime) {
+	for _, each := range strings.Split(accept, ",") {
+		typeAndQuality := strings.Split(strings.Trim(each, " "), ";")
+		if len(typeAndQuality) == 1 {
+			sorted = insertMime(sorted, mime{typeAndQuality[0], 1.0})
+		} else {
+			// take factor
+			parts := strings.Split(typeAndQuality[1], "=")
+			if len(parts) == 2 {
+				f, err := strconv.ParseFloat(parts[1], 64)
+				if err != nil {
+					traceLogger.Printf("unable to parse quality in %s, %v", each, err)
+				} else {
+					sorted = insertMime(sorted, mime{typeAndQuality[0], f})
+				}
+			}
+		}
+	}
+	return
+}

--- a/vendor/github.com/emicklei/go-restful/options_filter.go
+++ b/vendor/github.com/emicklei/go-restful/options_filter.go
@@ -1,0 +1,26 @@
+package restful
+
+import "strings"
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+// OPTIONSFilter is a filter function that inspects the Http Request for the OPTIONS method
+// and provides the response with a set of allowed methods for the request URL Path.
+// As for any filter, you can also install it for a particular WebService within a Container.
+// Note: this filter is not needed when using CrossOriginResourceSharing (for CORS).
+func (c *Container) OPTIONSFilter(req *Request, resp *Response, chain *FilterChain) {
+	if "OPTIONS" != req.Request.Method {
+		chain.ProcessFilter(req, resp)
+		return
+	}
+	resp.AddHeader(HEADER_Allow, strings.Join(c.computeAllowedMethods(req), ","))
+}
+
+// OPTIONSFilter is a filter function that inspects the Http Request for the OPTIONS method
+// and provides the response with a set of allowed methods for the request URL Path.
+// Note: this filter is not needed when using CrossOriginResourceSharing (for CORS).
+func OPTIONSFilter() FilterFunction {
+	return DefaultContainer.OPTIONSFilter
+}

--- a/vendor/github.com/emicklei/go-restful/parameter.go
+++ b/vendor/github.com/emicklei/go-restful/parameter.go
@@ -1,0 +1,114 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+const (
+	// PathParameterKind = indicator of Request parameter type "path"
+	PathParameterKind = iota
+
+	// QueryParameterKind = indicator of Request parameter type "query"
+	QueryParameterKind
+
+	// BodyParameterKind = indicator of Request parameter type "body"
+	BodyParameterKind
+
+	// HeaderParameterKind = indicator of Request parameter type "header"
+	HeaderParameterKind
+
+	// FormParameterKind = indicator of Request parameter type "form"
+	FormParameterKind
+)
+
+// Parameter is for documententing the parameter used in a Http Request
+// ParameterData kinds are Path,Query and Body
+type Parameter struct {
+	data *ParameterData
+}
+
+// ParameterData represents the state of a Parameter.
+// It is made public to make it accessible to e.g. the Swagger package.
+type ParameterData struct {
+	Name, Description, DataType, DataFormat string
+	Kind                                    int
+	Required                                bool
+	AllowableValues                         map[string]string
+	AllowMultiple                           bool
+	DefaultValue                            string
+}
+
+// Data returns the state of the Parameter
+func (p *Parameter) Data() ParameterData {
+	return *p.data
+}
+
+// Kind returns the parameter type indicator (see const for valid values)
+func (p *Parameter) Kind() int {
+	return p.data.Kind
+}
+
+func (p *Parameter) bePath() *Parameter {
+	p.data.Kind = PathParameterKind
+	return p
+}
+func (p *Parameter) beQuery() *Parameter {
+	p.data.Kind = QueryParameterKind
+	return p
+}
+func (p *Parameter) beBody() *Parameter {
+	p.data.Kind = BodyParameterKind
+	return p
+}
+
+func (p *Parameter) beHeader() *Parameter {
+	p.data.Kind = HeaderParameterKind
+	return p
+}
+
+func (p *Parameter) beForm() *Parameter {
+	p.data.Kind = FormParameterKind
+	return p
+}
+
+// Required sets the required field and returns the receiver
+func (p *Parameter) Required(required bool) *Parameter {
+	p.data.Required = required
+	return p
+}
+
+// AllowMultiple sets the allowMultiple field and returns the receiver
+func (p *Parameter) AllowMultiple(multiple bool) *Parameter {
+	p.data.AllowMultiple = multiple
+	return p
+}
+
+// AllowableValues sets the allowableValues field and returns the receiver
+func (p *Parameter) AllowableValues(values map[string]string) *Parameter {
+	p.data.AllowableValues = values
+	return p
+}
+
+// DataType sets the dataType field and returns the receiver
+func (p *Parameter) DataType(typeName string) *Parameter {
+	p.data.DataType = typeName
+	return p
+}
+
+// DataFormat sets the dataFormat field for Swagger UI
+func (p *Parameter) DataFormat(formatName string) *Parameter {
+	p.data.DataFormat = formatName
+	return p
+}
+
+// DefaultValue sets the default value field and returns the receiver
+func (p *Parameter) DefaultValue(stringRepresentation string) *Parameter {
+	p.data.DefaultValue = stringRepresentation
+	return p
+}
+
+// Description sets the description value field and returns the receiver
+func (p *Parameter) Description(doc string) *Parameter {
+	p.data.Description = doc
+	return p
+}

--- a/vendor/github.com/emicklei/go-restful/path_expression.go
+++ b/vendor/github.com/emicklei/go-restful/path_expression.go
@@ -1,0 +1,69 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// PathExpression holds a compiled path expression (RegExp) needed to match against
+// Http request paths and to extract path parameter values.
+type pathExpression struct {
+	LiteralCount int // the number of literal characters (means those not resulting from template variable substitution)
+	VarCount     int // the number of named parameters (enclosed by {}) in the path
+	Matcher      *regexp.Regexp
+	Source       string // Path as defined by the RouteBuilder
+	tokens       []string
+}
+
+// NewPathExpression creates a PathExpression from the input URL path.
+// Returns an error if the path is invalid.
+func newPathExpression(path string) (*pathExpression, error) {
+	expression, literalCount, varCount, tokens := templateToRegularExpression(path)
+	compiled, err := regexp.Compile(expression)
+	if err != nil {
+		return nil, err
+	}
+	return &pathExpression{literalCount, varCount, compiled, expression, tokens}, nil
+}
+
+// http://jsr311.java.net/nonav/releases/1.1/spec/spec3.html#x3-370003.7.3
+func templateToRegularExpression(template string) (expression string, literalCount int, varCount int, tokens []string) {
+	var buffer bytes.Buffer
+	buffer.WriteString("^")
+	//tokens = strings.Split(template, "/")
+	tokens = tokenizePath(template)
+	for _, each := range tokens {
+		if each == "" {
+			continue
+		}
+		buffer.WriteString("/")
+		if strings.HasPrefix(each, "{") {
+			// check for regular expression in variable
+			colon := strings.Index(each, ":")
+			if colon != -1 {
+				// extract expression
+				paramExpr := strings.TrimSpace(each[colon+1 : len(each)-1])
+				if paramExpr == "*" { // special case
+					buffer.WriteString("(.*)")
+				} else {
+					buffer.WriteString(fmt.Sprintf("(%s)", paramExpr)) // between colon and closing moustache
+				}
+			} else {
+				// plain var
+				buffer.WriteString("([^/]+?)")
+			}
+			varCount += 1
+		} else {
+			literalCount += len(each)
+			encoded := each // TODO URI encode
+			buffer.WriteString(regexp.QuoteMeta(encoded))
+		}
+	}
+	return strings.TrimRight(buffer.String(), "/") + "(/.*)?$", literalCount, varCount, tokens
+}

--- a/vendor/github.com/emicklei/go-restful/request.go
+++ b/vendor/github.com/emicklei/go-restful/request.go
@@ -1,0 +1,136 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bytes"
+	"compress/zlib"
+	"io/ioutil"
+	"net/http"
+)
+
+var defaultRequestContentType string
+
+var doCacheReadEntityBytes = false
+
+// Request is a wrapper for a http Request that provides convenience methods
+type Request struct {
+	Request           *http.Request
+	bodyContent       *[]byte // to cache the request body for multiple reads of ReadEntity
+	pathParameters    map[string]string
+	attributes        map[string]interface{} // for storing request-scoped values
+	selectedRoutePath string                 // root path + route path that matched the request, e.g. /meetings/{id}/attendees
+}
+
+func NewRequest(httpRequest *http.Request) *Request {
+	return &Request{
+		Request:        httpRequest,
+		pathParameters: map[string]string{},
+		attributes:     map[string]interface{}{},
+	} // empty parameters, attributes
+}
+
+// If ContentType is missing or */* is given then fall back to this type, otherwise
+// a "Unable to unmarshal content of type:" response is returned.
+// Valid values are restful.MIME_JSON and restful.MIME_XML
+// Example:
+// 	restful.DefaultRequestContentType(restful.MIME_JSON)
+func DefaultRequestContentType(mime string) {
+	defaultRequestContentType = mime
+}
+
+// SetCacheReadEntity controls whether the response data ([]byte) is cached such that ReadEntity is repeatable.
+// Default is true (due to backwardcompatibility). For better performance, you should set it to false if you don't need it.
+func SetCacheReadEntity(doCache bool) {
+	doCacheReadEntityBytes = doCache
+}
+
+// PathParameter accesses the Path parameter value by its name
+func (r *Request) PathParameter(name string) string {
+	return r.pathParameters[name]
+}
+
+// PathParameters accesses the Path parameter values
+func (r *Request) PathParameters() map[string]string {
+	return r.pathParameters
+}
+
+// QueryParameter returns the (first) Query parameter value by its name
+func (r *Request) QueryParameter(name string) string {
+	return r.Request.FormValue(name)
+}
+
+// BodyParameter parses the body of the request (once for typically a POST or a PUT) and returns the value of the given name or an error.
+func (r *Request) BodyParameter(name string) (string, error) {
+	err := r.Request.ParseForm()
+	if err != nil {
+		return "", err
+	}
+	return r.Request.PostFormValue(name), nil
+}
+
+// HeaderParameter returns the HTTP Header value of a Header name or empty if missing
+func (r *Request) HeaderParameter(name string) string {
+	return r.Request.Header.Get(name)
+}
+
+// ReadEntity checks the Accept header and reads the content into the entityPointer.
+func (r *Request) ReadEntity(entityPointer interface{}) (err error) {
+	contentType := r.Request.Header.Get(HEADER_ContentType)
+	contentEncoding := r.Request.Header.Get(HEADER_ContentEncoding)
+
+	// OLD feature, cache the body for reads
+	if doCacheReadEntityBytes {
+		if r.bodyContent == nil {
+			data, err := ioutil.ReadAll(r.Request.Body)
+			if err != nil {
+				return err
+			}
+			r.bodyContent = &data
+		}
+		r.Request.Body = ioutil.NopCloser(bytes.NewReader(*r.bodyContent))
+	}
+
+	// check if the request body needs decompression
+	if ENCODING_GZIP == contentEncoding {
+		gzipReader := currentCompressorProvider.AcquireGzipReader()
+		defer currentCompressorProvider.ReleaseGzipReader(gzipReader)
+		gzipReader.Reset(r.Request.Body)
+		r.Request.Body = gzipReader
+	} else if ENCODING_DEFLATE == contentEncoding {
+		zlibReader, err := zlib.NewReader(r.Request.Body)
+		if err != nil {
+			return err
+		}
+		r.Request.Body = zlibReader
+	}
+
+	// lookup the EntityReader, use defaultRequestContentType if needed and provided
+	entityReader, ok := entityAccessRegistry.accessorAt(contentType)
+	if !ok {
+		if len(defaultRequestContentType) != 0 {
+			entityReader, ok = entityAccessRegistry.accessorAt(defaultRequestContentType)
+		}
+		if !ok {
+			return NewError(http.StatusBadRequest, "Unable to unmarshal content of type:"+contentType)
+		}
+	}
+	return entityReader.Read(r, entityPointer)
+}
+
+// SetAttribute adds or replaces the attribute with the given value.
+func (r *Request) SetAttribute(name string, value interface{}) {
+	r.attributes[name] = value
+}
+
+// Attribute returns the value associated to the given name. Returns nil if absent.
+func (r Request) Attribute(name string) interface{} {
+	return r.attributes[name]
+}
+
+// SelectedRoutePath root path + route path that matched the request, e.g. /meetings/{id}/attendees
+func (r Request) SelectedRoutePath() string {
+	return r.selectedRoutePath
+}

--- a/vendor/github.com/emicklei/go-restful/response.go
+++ b/vendor/github.com/emicklei/go-restful/response.go
@@ -1,0 +1,235 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"errors"
+	"net/http"
+)
+
+// DEPRECATED, use DefaultResponseContentType(mime)
+var DefaultResponseMimeType string
+
+//PrettyPrintResponses controls the indentation feature of XML and JSON serialization
+var PrettyPrintResponses = true
+
+// Response is a wrapper on the actual http ResponseWriter
+// It provides several convenience methods to prepare and write response content.
+type Response struct {
+	http.ResponseWriter
+	requestAccept string   // mime-type what the Http Request says it wants to receive
+	routeProduces []string // mime-types what the Route says it can produce
+	statusCode    int      // HTTP status code that has been written explicity (if zero then net/http has written 200)
+	contentLength int      // number of bytes written for the response body
+	prettyPrint   bool     // controls the indentation feature of XML and JSON serialization. It is initialized using var PrettyPrintResponses.
+	err           error    // err property is kept when WriteError is called
+}
+
+// Creates a new response based on a http ResponseWriter.
+func NewResponse(httpWriter http.ResponseWriter) *Response {
+	return &Response{httpWriter, "", []string{}, http.StatusOK, 0, PrettyPrintResponses, nil} // empty content-types
+}
+
+// If Accept header matching fails, fall back to this type.
+// Valid values are restful.MIME_JSON and restful.MIME_XML
+// Example:
+// 	restful.DefaultResponseContentType(restful.MIME_JSON)
+func DefaultResponseContentType(mime string) {
+	DefaultResponseMimeType = mime
+}
+
+// InternalServerError writes the StatusInternalServerError header.
+// DEPRECATED, use WriteErrorString(http.StatusInternalServerError,reason)
+func (r Response) InternalServerError() Response {
+	r.WriteHeader(http.StatusInternalServerError)
+	return r
+}
+
+// PrettyPrint changes whether this response must produce pretty (line-by-line, indented) JSON or XML output.
+func (r *Response) PrettyPrint(bePretty bool) {
+	r.prettyPrint = bePretty
+}
+
+// AddHeader is a shortcut for .Header().Add(header,value)
+func (r Response) AddHeader(header string, value string) Response {
+	r.Header().Add(header, value)
+	return r
+}
+
+// SetRequestAccepts tells the response what Mime-type(s) the HTTP request said it wants to accept. Exposed for testing.
+func (r *Response) SetRequestAccepts(mime string) {
+	r.requestAccept = mime
+}
+
+// EntityWriter returns the registered EntityWriter that the entity (requested resource)
+// can write according to what the request wants (Accept) and what the Route can produce or what the restful defaults say.
+// If called before WriteEntity and WriteHeader then a false return value can be used to write a 406: Not Acceptable.
+func (r *Response) EntityWriter() (EntityReaderWriter, bool) {
+	sorted := sortedMimes(r.requestAccept)
+	for _, eachAccept := range sorted {
+		for _, eachProduce := range r.routeProduces {
+			if eachProduce == eachAccept.media {
+				if w, ok := entityAccessRegistry.accessorAt(eachAccept.media); ok {
+					return w, true
+				}
+			}
+		}
+		if eachAccept.media == "*/*" {
+			for _, each := range r.routeProduces {
+				if w, ok := entityAccessRegistry.accessorAt(each); ok {
+					return w, true
+				}
+			}
+		}
+	}
+	// if requestAccept is empty
+	writer, ok := entityAccessRegistry.accessorAt(r.requestAccept)
+	if !ok {
+		// if not registered then fallback to the defaults (if set)
+		if DefaultResponseMimeType == MIME_JSON {
+			return entityAccessRegistry.accessorAt(MIME_JSON)
+		}
+		if DefaultResponseMimeType == MIME_XML {
+			return entityAccessRegistry.accessorAt(MIME_XML)
+		}
+		// Fallback to whatever the route says it can produce.
+		// https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+		for _, each := range r.routeProduces {
+			if w, ok := entityAccessRegistry.accessorAt(each); ok {
+				return w, true
+			}
+		}
+		if trace {
+			traceLogger.Printf("no registered EntityReaderWriter found for %s", r.requestAccept)
+		}
+	}
+	return writer, ok
+}
+
+// WriteEntity calls WriteHeaderAndEntity with Http Status OK (200)
+func (r *Response) WriteEntity(value interface{}) error {
+	return r.WriteHeaderAndEntity(http.StatusOK, value)
+}
+
+// WriteHeaderAndEntity marshals the value using the representation denoted by the Accept Header and the registered EntityWriters.
+// If no Accept header is specified (or */*) then respond with the Content-Type as specified by the first in the Route.Produces.
+// If an Accept header is specified then respond with the Content-Type as specified by the first in the Route.Produces that is matched with the Accept header.
+// If the value is nil then no response is send except for the Http status. You may want to call WriteHeader(http.StatusNotFound) instead.
+// If there is no writer available that can represent the value in the requested MIME type then Http Status NotAcceptable is written.
+// Current implementation ignores any q-parameters in the Accept Header.
+// Returns an error if the value could not be written on the response.
+func (r *Response) WriteHeaderAndEntity(status int, value interface{}) error {
+	writer, ok := r.EntityWriter()
+	if !ok {
+		r.WriteHeader(http.StatusNotAcceptable)
+		return nil
+	}
+	return writer.Write(r, status, value)
+}
+
+// WriteAsXml is a convenience method for writing a value in xml (requires Xml tags on the value)
+// It uses the standard encoding/xml package for marshalling the value ; not using a registered EntityReaderWriter.
+func (r *Response) WriteAsXml(value interface{}) error {
+	return writeXML(r, http.StatusOK, MIME_XML, value)
+}
+
+// WriteHeaderAndXml is a convenience method for writing a status and value in xml (requires Xml tags on the value)
+// It uses the standard encoding/xml package for marshalling the value ; not using a registered EntityReaderWriter.
+func (r *Response) WriteHeaderAndXml(status int, value interface{}) error {
+	return writeXML(r, status, MIME_XML, value)
+}
+
+// WriteAsJson is a convenience method for writing a value in json.
+// It uses the standard encoding/json package for marshalling the value ; not using a registered EntityReaderWriter.
+func (r *Response) WriteAsJson(value interface{}) error {
+	return writeJSON(r, http.StatusOK, MIME_JSON, value)
+}
+
+// WriteJson is a convenience method for writing a value in Json with a given Content-Type.
+// It uses the standard encoding/json package for marshalling the value ; not using a registered EntityReaderWriter.
+func (r *Response) WriteJson(value interface{}, contentType string) error {
+	return writeJSON(r, http.StatusOK, contentType, value)
+}
+
+// WriteHeaderAndJson is a convenience method for writing the status and a value in Json with a given Content-Type.
+// It uses the standard encoding/json package for marshalling the value ; not using a registered EntityReaderWriter.
+func (r *Response) WriteHeaderAndJson(status int, value interface{}, contentType string) error {
+	return writeJSON(r, status, contentType, value)
+}
+
+// WriteError write the http status and the error string on the response.
+func (r *Response) WriteError(httpStatus int, err error) error {
+	r.err = err
+	return r.WriteErrorString(httpStatus, err.Error())
+}
+
+// WriteServiceError is a convenience method for a responding with a status and a ServiceError
+func (r *Response) WriteServiceError(httpStatus int, err ServiceError) error {
+	r.err = err
+	return r.WriteHeaderAndEntity(httpStatus, err)
+}
+
+// WriteErrorString is a convenience method for an error status with the actual error
+func (r *Response) WriteErrorString(httpStatus int, errorReason string) error {
+	if r.err == nil {
+		// if not called from WriteError
+		r.err = errors.New(errorReason)
+	}
+	r.WriteHeader(httpStatus)
+	if _, err := r.Write([]byte(errorReason)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Flush implements http.Flusher interface, which sends any buffered data to the client.
+func (r *Response) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	} else if trace {
+		traceLogger.Printf("ResponseWriter %v doesn't support Flush", r)
+	}
+}
+
+// WriteHeader is overridden to remember the Status Code that has been written.
+// Changes to the Header of the response have no effect after this.
+func (r *Response) WriteHeader(httpStatus int) {
+	r.statusCode = httpStatus
+	r.ResponseWriter.WriteHeader(httpStatus)
+}
+
+// StatusCode returns the code that has been written using WriteHeader.
+func (r Response) StatusCode() int {
+	if 0 == r.statusCode {
+		// no status code has been written yet; assume OK
+		return http.StatusOK
+	}
+	return r.statusCode
+}
+
+// Write writes the data to the connection as part of an HTTP reply.
+// Write is part of http.ResponseWriter interface.
+func (r *Response) Write(bytes []byte) (int, error) {
+	written, err := r.ResponseWriter.Write(bytes)
+	r.contentLength += written
+	return written, err
+}
+
+// ContentLength returns the number of bytes written for the response content.
+// Note that this value is only correct if all data is written through the Response using its Write* methods.
+// Data written directly using the underlying http.ResponseWriter is not accounted for.
+func (r Response) ContentLength() int {
+	return r.contentLength
+}
+
+// CloseNotify is part of http.CloseNotifier interface
+func (r Response) CloseNotify() <-chan bool {
+	return r.ResponseWriter.(http.CloseNotifier).CloseNotify()
+}
+
+// Error returns the err created by WriteError
+func (r Response) Error() error {
+	return r.err
+}

--- a/vendor/github.com/emicklei/go-restful/route.go
+++ b/vendor/github.com/emicklei/go-restful/route.go
@@ -1,0 +1,183 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+)
+
+// RouteFunction declares the signature of a function that can be bound to a Route.
+type RouteFunction func(*Request, *Response)
+
+// Route binds a HTTP Method,Path,Consumes combination to a RouteFunction.
+type Route struct {
+	Method   string
+	Produces []string
+	Consumes []string
+	Path     string // webservice root path + described path
+	Function RouteFunction
+	Filters  []FilterFunction
+
+	// cached values for dispatching
+	relativePath string
+	pathParts    []string
+	pathExpr     *pathExpression // cached compilation of relativePath as RegExp
+
+	// documentation
+	Doc                     string
+	Notes                   string
+	Operation               string
+	ParameterDocs           []*Parameter
+	ResponseErrors          map[int]ResponseError
+	ReadSample, WriteSample interface{} // structs that model an example request or response payload
+}
+
+// Initialize for Route
+func (r *Route) postBuild() {
+	r.pathParts = tokenizePath(r.Path)
+}
+
+// Create Request and Response from their http versions
+func (r *Route) wrapRequestResponse(httpWriter http.ResponseWriter, httpRequest *http.Request) (*Request, *Response) {
+	params := r.extractParameters(httpRequest.URL.Path)
+	wrappedRequest := NewRequest(httpRequest)
+	wrappedRequest.pathParameters = params
+	wrappedRequest.selectedRoutePath = r.Path
+	wrappedResponse := NewResponse(httpWriter)
+	wrappedResponse.requestAccept = httpRequest.Header.Get(HEADER_Accept)
+	wrappedResponse.routeProduces = r.Produces
+	return wrappedRequest, wrappedResponse
+}
+
+// dispatchWithFilters call the function after passing through its own filters
+func (r *Route) dispatchWithFilters(wrappedRequest *Request, wrappedResponse *Response) {
+	if len(r.Filters) > 0 {
+		chain := FilterChain{Filters: r.Filters, Target: r.Function}
+		chain.ProcessFilter(wrappedRequest, wrappedResponse)
+	} else {
+		// unfiltered
+		r.Function(wrappedRequest, wrappedResponse)
+	}
+}
+
+// Return whether the mimeType matches to what this Route can produce.
+func (r Route) matchesAccept(mimeTypesWithQuality string) bool {
+	parts := strings.Split(mimeTypesWithQuality, ",")
+	for _, each := range parts {
+		var withoutQuality string
+		if strings.Contains(each, ";") {
+			withoutQuality = strings.Split(each, ";")[0]
+		} else {
+			withoutQuality = each
+		}
+		// trim before compare
+		withoutQuality = strings.Trim(withoutQuality, " ")
+		if withoutQuality == "*/*" {
+			return true
+		}
+		for _, producibleType := range r.Produces {
+			if producibleType == "*/*" || producibleType == withoutQuality {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Return whether this Route can consume content with a type specified by mimeTypes (can be empty).
+func (r Route) matchesContentType(mimeTypes string) bool {
+
+	if len(r.Consumes) == 0 {
+		// did not specify what it can consume ;  any media type (“*/*”) is assumed
+		return true
+	}
+
+	if len(mimeTypes) == 0 {
+		// idempotent methods with (most-likely or garanteed) empty content match missing Content-Type
+		m := r.Method
+		if m == "GET" || m == "HEAD" || m == "OPTIONS" || m == "DELETE" || m == "TRACE" {
+			return true
+		}
+		// proceed with default
+		mimeTypes = MIME_OCTET
+	}
+
+	parts := strings.Split(mimeTypes, ",")
+	for _, each := range parts {
+		var contentType string
+		if strings.Contains(each, ";") {
+			contentType = strings.Split(each, ";")[0]
+		} else {
+			contentType = each
+		}
+		// trim before compare
+		contentType = strings.Trim(contentType, " ")
+		for _, consumeableType := range r.Consumes {
+			if consumeableType == "*/*" || consumeableType == contentType {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Extract the parameters from the request url path
+func (r Route) extractParameters(urlPath string) map[string]string {
+	urlParts := tokenizePath(urlPath)
+	pathParameters := map[string]string{}
+	for i, key := range r.pathParts {
+		var value string
+		if i >= len(urlParts) {
+			value = ""
+		} else {
+			value = urlParts[i]
+		}
+		if strings.HasPrefix(key, "{") { // path-parameter
+			if colon := strings.Index(key, ":"); colon != -1 {
+				// extract by regex
+				regPart := key[colon+1 : len(key)-1]
+				keyPart := key[1:colon]
+				if regPart == "*" {
+					pathParameters[keyPart] = untokenizePath(i, urlParts)
+					break
+				} else {
+					pathParameters[keyPart] = value
+				}
+			} else {
+				// without enclosing {}
+				pathParameters[key[1:len(key)-1]] = value
+			}
+		}
+	}
+	return pathParameters
+}
+
+// Untokenize back into an URL path using the slash separator
+func untokenizePath(offset int, parts []string) string {
+	var buffer bytes.Buffer
+	for p := offset; p < len(parts); p++ {
+		buffer.WriteString(parts[p])
+		// do not end
+		if p < len(parts)-1 {
+			buffer.WriteString("/")
+		}
+	}
+	return buffer.String()
+}
+
+// Tokenize an URL path using the slash separator ; the result does not have empty tokens
+func tokenizePath(path string) []string {
+	if "/" == path {
+		return []string{}
+	}
+	return strings.Split(strings.Trim(path, "/"), "/")
+}
+
+// for debugging
+func (r Route) String() string {
+	return r.Method + " " + r.Path
+}

--- a/vendor/github.com/emicklei/go-restful/route_builder.go
+++ b/vendor/github.com/emicklei/go-restful/route_builder.go
@@ -1,0 +1,240 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+
+	"github.com/emicklei/go-restful/log"
+)
+
+// RouteBuilder is a helper to construct Routes.
+type RouteBuilder struct {
+	rootPath    string
+	currentPath string
+	produces    []string
+	consumes    []string
+	httpMethod  string        // required
+	function    RouteFunction // required
+	filters     []FilterFunction
+	// documentation
+	doc                     string
+	notes                   string
+	operation               string
+	readSample, writeSample interface{}
+	parameters              []*Parameter
+	errorMap                map[int]ResponseError
+}
+
+// Do evaluates each argument with the RouteBuilder itself.
+// This allows you to follow DRY principles without breaking the fluent programming style.
+// Example:
+// 		ws.Route(ws.DELETE("/{name}").To(t.deletePerson).Do(Returns200, Returns500))
+//
+//		func Returns500(b *RouteBuilder) {
+//			b.Returns(500, "Internal Server Error", restful.ServiceError{})
+//		}
+func (b *RouteBuilder) Do(oneArgBlocks ...func(*RouteBuilder)) *RouteBuilder {
+	for _, each := range oneArgBlocks {
+		each(b)
+	}
+	return b
+}
+
+// To bind the route to a function.
+// If this route is matched with the incoming Http Request then call this function with the *Request,*Response pair. Required.
+func (b *RouteBuilder) To(function RouteFunction) *RouteBuilder {
+	b.function = function
+	return b
+}
+
+// Method specifies what HTTP method to match. Required.
+func (b *RouteBuilder) Method(method string) *RouteBuilder {
+	b.httpMethod = method
+	return b
+}
+
+// Produces specifies what MIME types can be produced ; the matched one will appear in the Content-Type Http header.
+func (b *RouteBuilder) Produces(mimeTypes ...string) *RouteBuilder {
+	b.produces = mimeTypes
+	return b
+}
+
+// Consumes specifies what MIME types can be consumes ; the Accept Http header must matched any of these
+func (b *RouteBuilder) Consumes(mimeTypes ...string) *RouteBuilder {
+	b.consumes = mimeTypes
+	return b
+}
+
+// Path specifies the relative (w.r.t WebService root path) URL path to match. Default is "/".
+func (b *RouteBuilder) Path(subPath string) *RouteBuilder {
+	b.currentPath = subPath
+	return b
+}
+
+// Doc tells what this route is all about. Optional.
+func (b *RouteBuilder) Doc(documentation string) *RouteBuilder {
+	b.doc = documentation
+	return b
+}
+
+// A verbose explanation of the operation behavior. Optional.
+func (b *RouteBuilder) Notes(notes string) *RouteBuilder {
+	b.notes = notes
+	return b
+}
+
+// Reads tells what resource type will be read from the request payload. Optional.
+// A parameter of type "body" is added ,required is set to true and the dataType is set to the qualified name of the sample's type.
+func (b *RouteBuilder) Reads(sample interface{}) *RouteBuilder {
+	b.readSample = sample
+	typeAsName := reflect.TypeOf(sample).String()
+	bodyParameter := &Parameter{&ParameterData{Name: "body"}}
+	bodyParameter.beBody()
+	bodyParameter.Required(true)
+	bodyParameter.DataType(typeAsName)
+	b.Param(bodyParameter)
+	return b
+}
+
+// ParameterNamed returns a Parameter already known to the RouteBuilder. Returns nil if not.
+// Use this to modify or extend information for the Parameter (through its Data()).
+func (b RouteBuilder) ParameterNamed(name string) (p *Parameter) {
+	for _, each := range b.parameters {
+		if each.Data().Name == name {
+			return each
+		}
+	}
+	return p
+}
+
+// Writes tells what resource type will be written as the response payload. Optional.
+func (b *RouteBuilder) Writes(sample interface{}) *RouteBuilder {
+	b.writeSample = sample
+	return b
+}
+
+// Param allows you to document the parameters of the Route. It adds a new Parameter (does not check for duplicates).
+func (b *RouteBuilder) Param(parameter *Parameter) *RouteBuilder {
+	if b.parameters == nil {
+		b.parameters = []*Parameter{}
+	}
+	b.parameters = append(b.parameters, parameter)
+	return b
+}
+
+// Operation allows you to document what the actual method/function call is of the Route.
+// Unless called, the operation name is derived from the RouteFunction set using To(..).
+func (b *RouteBuilder) Operation(name string) *RouteBuilder {
+	b.operation = name
+	return b
+}
+
+// ReturnsError is deprecated, use Returns instead.
+func (b *RouteBuilder) ReturnsError(code int, message string, model interface{}) *RouteBuilder {
+	log.Print("ReturnsError is deprecated, use Returns instead.")
+	return b.Returns(code, message, model)
+}
+
+// Returns allows you to document what responses (errors or regular) can be expected.
+// The model parameter is optional ; either pass a struct instance or use nil if not applicable.
+func (b *RouteBuilder) Returns(code int, message string, model interface{}) *RouteBuilder {
+	err := ResponseError{
+		Code:    code,
+		Message: message,
+		Model:   model,
+	}
+	// lazy init because there is no NewRouteBuilder (yet)
+	if b.errorMap == nil {
+		b.errorMap = map[int]ResponseError{}
+	}
+	b.errorMap[code] = err
+	return b
+}
+
+type ResponseError struct {
+	Code    int
+	Message string
+	Model   interface{}
+}
+
+func (b *RouteBuilder) servicePath(path string) *RouteBuilder {
+	b.rootPath = path
+	return b
+}
+
+// Filter appends a FilterFunction to the end of filters for this Route to build.
+func (b *RouteBuilder) Filter(filter FilterFunction) *RouteBuilder {
+	b.filters = append(b.filters, filter)
+	return b
+}
+
+// If no specific Route path then set to rootPath
+// If no specific Produces then set to rootProduces
+// If no specific Consumes then set to rootConsumes
+func (b *RouteBuilder) copyDefaults(rootProduces, rootConsumes []string) {
+	if len(b.produces) == 0 {
+		b.produces = rootProduces
+	}
+	if len(b.consumes) == 0 {
+		b.consumes = rootConsumes
+	}
+}
+
+// Build creates a new Route using the specification details collected by the RouteBuilder
+func (b *RouteBuilder) Build() Route {
+	pathExpr, err := newPathExpression(b.currentPath)
+	if err != nil {
+		log.Printf("[restful] Invalid path:%s because:%v", b.currentPath, err)
+		os.Exit(1)
+	}
+	if b.function == nil {
+		log.Printf("[restful] No function specified for route:" + b.currentPath)
+		os.Exit(1)
+	}
+	operationName := b.operation
+	if len(operationName) == 0 && b.function != nil {
+		// extract from definition
+		operationName = nameOfFunction(b.function)
+	}
+	route := Route{
+		Method:         b.httpMethod,
+		Path:           concatPath(b.rootPath, b.currentPath),
+		Produces:       b.produces,
+		Consumes:       b.consumes,
+		Function:       b.function,
+		Filters:        b.filters,
+		relativePath:   b.currentPath,
+		pathExpr:       pathExpr,
+		Doc:            b.doc,
+		Notes:          b.notes,
+		Operation:      operationName,
+		ParameterDocs:  b.parameters,
+		ResponseErrors: b.errorMap,
+		ReadSample:     b.readSample,
+		WriteSample:    b.writeSample}
+	route.postBuild()
+	return route
+}
+
+func concatPath(path1, path2 string) string {
+	return strings.TrimRight(path1, "/") + "/" + strings.TrimLeft(path2, "/")
+}
+
+// nameOfFunction returns the short name of the function f for documentation.
+// It uses a runtime feature for debugging ; its value may change for later Go versions.
+func nameOfFunction(f interface{}) string {
+	fun := runtime.FuncForPC(reflect.ValueOf(f).Pointer())
+	tokenized := strings.Split(fun.Name(), ".")
+	last := tokenized[len(tokenized)-1]
+	last = strings.TrimSuffix(last, ")·fm") // < Go 1.5
+	last = strings.TrimSuffix(last, ")-fm") // Go 1.5
+	last = strings.TrimSuffix(last, "·fm")  // < Go 1.5
+	last = strings.TrimSuffix(last, "-fm")  // Go 1.5
+	return last
+}

--- a/vendor/github.com/emicklei/go-restful/router.go
+++ b/vendor/github.com/emicklei/go-restful/router.go
@@ -1,0 +1,18 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import "net/http"
+
+// A RouteSelector finds the best matching Route given the input HTTP Request
+type RouteSelector interface {
+
+	// SelectRoute finds a Route given the input HTTP Request and a list of WebServices.
+	// It returns a selected Route and its containing WebService or an error indicating
+	// a problem.
+	SelectRoute(
+		webServices []*WebService,
+		httpRequest *http.Request) (selectedService *WebService, selected *Route, err error)
+}

--- a/vendor/github.com/emicklei/go-restful/service_error.go
+++ b/vendor/github.com/emicklei/go-restful/service_error.go
@@ -1,0 +1,23 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import "fmt"
+
+// ServiceError is a transport object to pass information about a non-Http error occurred in a WebService while processing a request.
+type ServiceError struct {
+	Code    int
+	Message string
+}
+
+// NewError returns a ServiceError using the code and reason
+func NewError(code int, message string) ServiceError {
+	return ServiceError{Code: code, Message: message}
+}
+
+// Error returns a text representation of the service error
+func (s ServiceError) Error() string {
+	return fmt.Sprintf("[ServiceError:%v] %v", s.Code, s.Message)
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/api_declaration_list.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/api_declaration_list.go
@@ -1,0 +1,64 @@
+package swagger
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// ApiDeclarationList maintains an ordered list of ApiDeclaration.
+type ApiDeclarationList struct {
+	List []ApiDeclaration
+}
+
+// At returns the ApiDeclaration by its path unless absent, then ok is false
+func (l *ApiDeclarationList) At(path string) (a ApiDeclaration, ok bool) {
+	for _, each := range l.List {
+		if each.ResourcePath == path {
+			return each, true
+		}
+	}
+	return a, false
+}
+
+// Put adds or replaces a ApiDeclaration with this name
+func (l *ApiDeclarationList) Put(path string, a ApiDeclaration) {
+	// maybe replace existing
+	for i, each := range l.List {
+		if each.ResourcePath == path {
+			// replace
+			l.List[i] = a
+			return
+		}
+	}
+	// add
+	l.List = append(l.List, a)
+}
+
+// Do enumerates all the properties, each with its assigned name
+func (l *ApiDeclarationList) Do(block func(path string, decl ApiDeclaration)) {
+	for _, each := range l.List {
+		block(each.ResourcePath, each)
+	}
+}
+
+// MarshalJSON writes the ModelPropertyList as if it was a map[string]ModelProperty
+func (l ApiDeclarationList) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	buf.WriteString("{\n")
+	for i, each := range l.List {
+		buf.WriteString("\"")
+		buf.WriteString(each.ResourcePath)
+		buf.WriteString("\": ")
+		encoder.Encode(each)
+		if i < len(l.List)-1 {
+			buf.WriteString(",\n")
+		}
+	}
+	buf.WriteString("}")
+	return buf.Bytes(), nil
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/config.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/config.go
@@ -1,0 +1,38 @@
+package swagger
+
+import (
+	"net/http"
+
+	"github.com/emicklei/go-restful"
+)
+
+// PostBuildDeclarationMapFunc can be used to modify the api declaration map.
+type PostBuildDeclarationMapFunc func(apiDeclarationMap *ApiDeclarationList)
+
+type MapSchemaFormatFunc func(typeName string) string
+
+type Config struct {
+	// url where the services are available, e.g. http://localhost:8080
+	// if left empty then the basePath of Swagger is taken from the actual request
+	WebServicesUrl string
+	// path where the JSON api is avaiable , e.g. /apidocs
+	ApiPath string
+	// [optional] path where the swagger UI will be served, e.g. /swagger
+	SwaggerPath string
+	// [optional] location of folder containing Swagger HTML5 application index.html
+	SwaggerFilePath string
+	// api listing is constructed from this list of restful WebServices.
+	WebServices []*restful.WebService
+	// will serve all static content (scripts,pages,images)
+	StaticHandler http.Handler
+	// [optional] on default CORS (Cross-Origin-Resource-Sharing) is enabled.
+	DisableCORS bool
+	// Top-level API version. Is reflected in the resource listing.
+	ApiVersion string
+	// If set then call this handler after building the complete ApiDeclaration Map
+	PostBuildHandler PostBuildDeclarationMapFunc
+	// Swagger global info struct
+	Info Info
+	// [optional] If set, model builder should call this handler to get addition typename-to-swagger-format-field convertion.
+	SchemaFormatHandler MapSchemaFormatFunc
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/model_builder.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/model_builder.go
@@ -1,0 +1,460 @@
+package swagger
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+)
+
+// ModelBuildable is used for extending Structs that need more control over
+// how the Model appears in the Swagger api declaration.
+type ModelBuildable interface {
+	PostBuildModel(m *Model) *Model
+}
+
+type modelBuilder struct {
+	Models *ModelList
+	Config *Config
+}
+
+type documentable interface {
+	SwaggerDoc() map[string]string
+}
+
+// Check if this structure has a method with signature func (<theModel>) SwaggerDoc() map[string]string
+// If it exists, retrive the documentation and overwrite all struct tag descriptions
+func getDocFromMethodSwaggerDoc2(model reflect.Type) map[string]string {
+	if docable, ok := reflect.New(model).Elem().Interface().(documentable); ok {
+		return docable.SwaggerDoc()
+	}
+	return make(map[string]string)
+}
+
+// addModelFrom creates and adds a Model to the builder and detects and calls
+// the post build hook for customizations
+func (b modelBuilder) addModelFrom(sample interface{}) {
+	if modelOrNil := b.addModel(reflect.TypeOf(sample), ""); modelOrNil != nil {
+		// allow customizations
+		if buildable, ok := sample.(ModelBuildable); ok {
+			modelOrNil = buildable.PostBuildModel(modelOrNil)
+			b.Models.Put(modelOrNil.Id, *modelOrNil)
+		}
+	}
+}
+
+func (b modelBuilder) addModel(st reflect.Type, nameOverride string) *Model {
+	// Turn pointers into simpler types so further checks are
+	// correct.
+	if st.Kind() == reflect.Ptr {
+		st = st.Elem()
+	}
+
+	modelName := b.keyFrom(st)
+	if nameOverride != "" {
+		modelName = nameOverride
+	}
+	// no models needed for primitive types
+	if b.isPrimitiveType(modelName) {
+		return nil
+	}
+	// golang encoding/json packages says array and slice values encode as
+	// JSON arrays, except that []byte encodes as a base64-encoded string.
+	// If we see a []byte here, treat it at as a primitive type (string)
+	// and deal with it in buildArrayTypeProperty.
+	if (st.Kind() == reflect.Slice || st.Kind() == reflect.Array) &&
+		st.Elem().Kind() == reflect.Uint8 {
+		return nil
+	}
+	// see if we already have visited this model
+	if _, ok := b.Models.At(modelName); ok {
+		return nil
+	}
+	sm := Model{
+		Id:         modelName,
+		Required:   []string{},
+		Properties: ModelPropertyList{}}
+
+	// reference the model before further initializing (enables recursive structs)
+	b.Models.Put(modelName, sm)
+
+	// check for slice or array
+	if st.Kind() == reflect.Slice || st.Kind() == reflect.Array {
+		b.addModel(st.Elem(), "")
+		return &sm
+	}
+	// check for structure or primitive type
+	if st.Kind() != reflect.Struct {
+		return &sm
+	}
+
+	fullDoc := getDocFromMethodSwaggerDoc2(st)
+	modelDescriptions := []string{}
+
+	for i := 0; i < st.NumField(); i++ {
+		field := st.Field(i)
+		jsonName, modelDescription, prop := b.buildProperty(field, &sm, modelName)
+		if len(modelDescription) > 0 {
+			modelDescriptions = append(modelDescriptions, modelDescription)
+		}
+
+		// add if not omitted
+		if len(jsonName) != 0 {
+			// update description
+			if fieldDoc, ok := fullDoc[jsonName]; ok {
+				prop.Description = fieldDoc
+			}
+			// update Required
+			if b.isPropertyRequired(field) {
+				sm.Required = append(sm.Required, jsonName)
+			}
+			sm.Properties.Put(jsonName, prop)
+		}
+	}
+
+	// We always overwrite documentation if SwaggerDoc method exists
+	// "" is special for documenting the struct itself
+	if modelDoc, ok := fullDoc[""]; ok {
+		sm.Description = modelDoc
+	} else if len(modelDescriptions) != 0 {
+		sm.Description = strings.Join(modelDescriptions, "\n")
+	}
+
+	// update model builder with completed model
+	b.Models.Put(modelName, sm)
+
+	return &sm
+}
+
+func (b modelBuilder) isPropertyRequired(field reflect.StructField) bool {
+	required := true
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		s := strings.Split(jsonTag, ",")
+		if len(s) > 1 && s[1] == "omitempty" {
+			return false
+		}
+	}
+	return required
+}
+
+func (b modelBuilder) buildProperty(field reflect.StructField, model *Model, modelName string) (jsonName, modelDescription string, prop ModelProperty) {
+	jsonName = b.jsonNameOfField(field)
+	if len(jsonName) == 0 {
+		// empty name signals skip property
+		return "", "", prop
+	}
+
+	if field.Name == "XMLName" && field.Type.String() == "xml.Name" {
+		// property is metadata for the xml.Name attribute, can be skipped
+		return "", "", prop
+	}
+
+	if tag := field.Tag.Get("modelDescription"); tag != "" {
+		modelDescription = tag
+	}
+
+	prop.setPropertyMetadata(field)
+	if prop.Type != nil {
+		return jsonName, modelDescription, prop
+	}
+	fieldType := field.Type
+
+	// check if type is doing its own marshalling
+	marshalerType := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	if fieldType.Implements(marshalerType) {
+		var pType = "string"
+		if prop.Type == nil {
+			prop.Type = &pType
+		}
+		if prop.Format == "" {
+			prop.Format = b.jsonSchemaFormat(fieldType.String())
+		}
+		return jsonName, modelDescription, prop
+	}
+
+	// check if annotation says it is a string
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		s := strings.Split(jsonTag, ",")
+		if len(s) > 1 && s[1] == "string" {
+			stringt := "string"
+			prop.Type = &stringt
+			return jsonName, modelDescription, prop
+		}
+	}
+
+	fieldKind := fieldType.Kind()
+	switch {
+	case fieldKind == reflect.Struct:
+		jsonName, prop := b.buildStructTypeProperty(field, jsonName, model)
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.Slice || fieldKind == reflect.Array:
+		jsonName, prop := b.buildArrayTypeProperty(field, jsonName, modelName)
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.Ptr:
+		jsonName, prop := b.buildPointerTypeProperty(field, jsonName, modelName)
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.String:
+		stringt := "string"
+		prop.Type = &stringt
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.Map:
+		// if it's a map, it's unstructured, and swagger 1.2 can't handle it
+		objectType := "object"
+		prop.Type = &objectType
+		return jsonName, modelDescription, prop
+	}
+
+	if b.isPrimitiveType(fieldType.String()) {
+		mapped := b.jsonSchemaType(fieldType.String())
+		prop.Type = &mapped
+		prop.Format = b.jsonSchemaFormat(fieldType.String())
+		return jsonName, modelDescription, prop
+	}
+	modelType := fieldType.String()
+	prop.Ref = &modelType
+
+	if fieldType.Name() == "" { // override type of anonymous structs
+		nestedTypeName := modelName + "." + jsonName
+		prop.Ref = &nestedTypeName
+		b.addModel(fieldType, nestedTypeName)
+	}
+	return jsonName, modelDescription, prop
+}
+
+func hasNamedJSONTag(field reflect.StructField) bool {
+	parts := strings.Split(field.Tag.Get("json"), ",")
+	if len(parts) == 0 {
+		return false
+	}
+	for _, s := range parts[1:] {
+		if s == "inline" {
+			return false
+		}
+	}
+	return len(parts[0]) > 0
+}
+
+func (b modelBuilder) buildStructTypeProperty(field reflect.StructField, jsonName string, model *Model) (nameJson string, prop ModelProperty) {
+	prop.setPropertyMetadata(field)
+	// Check for type override in tag
+	if prop.Type != nil {
+		return jsonName, prop
+	}
+	fieldType := field.Type
+	// check for anonymous
+	if len(fieldType.Name()) == 0 {
+		// anonymous
+		anonType := model.Id + "." + jsonName
+		b.addModel(fieldType, anonType)
+		prop.Ref = &anonType
+		return jsonName, prop
+	}
+
+	if field.Name == fieldType.Name() && field.Anonymous && !hasNamedJSONTag(field) {
+		// embedded struct
+		sub := modelBuilder{new(ModelList), b.Config}
+		sub.addModel(fieldType, "")
+		subKey := sub.keyFrom(fieldType)
+		// merge properties from sub
+		subModel, _ := sub.Models.At(subKey)
+		subModel.Properties.Do(func(k string, v ModelProperty) {
+			model.Properties.Put(k, v)
+			// if subModel says this property is required then include it
+			required := false
+			for _, each := range subModel.Required {
+				if k == each {
+					required = true
+					break
+				}
+			}
+			if required {
+				model.Required = append(model.Required, k)
+			}
+		})
+		// add all new referenced models
+		sub.Models.Do(func(key string, sub Model) {
+			if key != subKey {
+				if _, ok := b.Models.At(key); !ok {
+					b.Models.Put(key, sub)
+				}
+			}
+		})
+		// empty name signals skip property
+		return "", prop
+	}
+	// simple struct
+	b.addModel(fieldType, "")
+	var pType = fieldType.String()
+	prop.Ref = &pType
+	return jsonName, prop
+}
+
+func (b modelBuilder) buildArrayTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop ModelProperty) {
+	// check for type override in tags
+	prop.setPropertyMetadata(field)
+	if prop.Type != nil {
+		return jsonName, prop
+	}
+	fieldType := field.Type
+	if fieldType.Elem().Kind() == reflect.Uint8 {
+		stringt := "string"
+		prop.Type = &stringt
+		return jsonName, prop
+	}
+	var pType = "array"
+	prop.Type = &pType
+	isPrimitive := b.isPrimitiveType(fieldType.Elem().Name())
+	elemTypeName := b.getElementTypeName(modelName, jsonName, fieldType.Elem())
+	prop.Items = new(Item)
+	if isPrimitive {
+		mapped := b.jsonSchemaType(elemTypeName)
+		prop.Items.Type = &mapped
+	} else {
+		prop.Items.Ref = &elemTypeName
+	}
+	// add|overwrite model for element type
+	if fieldType.Elem().Kind() == reflect.Ptr {
+		fieldType = fieldType.Elem()
+	}
+	if !isPrimitive {
+		b.addModel(fieldType.Elem(), elemTypeName)
+	}
+	return jsonName, prop
+}
+
+func (b modelBuilder) buildPointerTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop ModelProperty) {
+	prop.setPropertyMetadata(field)
+	// Check for type override in tags
+	if prop.Type != nil {
+		return jsonName, prop
+	}
+	fieldType := field.Type
+
+	// override type of pointer to list-likes
+	if fieldType.Elem().Kind() == reflect.Slice || fieldType.Elem().Kind() == reflect.Array {
+		var pType = "array"
+		prop.Type = &pType
+		isPrimitive := b.isPrimitiveType(fieldType.Elem().Elem().Name())
+		elemName := b.getElementTypeName(modelName, jsonName, fieldType.Elem().Elem())
+		if isPrimitive {
+			primName := b.jsonSchemaType(elemName)
+			prop.Items = &Item{Ref: &primName}
+		} else {
+			prop.Items = &Item{Ref: &elemName}
+		}
+		if !isPrimitive {
+			// add|overwrite model for element type
+			b.addModel(fieldType.Elem().Elem(), elemName)
+		}
+	} else {
+		// non-array, pointer type
+		var pType = b.jsonSchemaType(fieldType.String()[1:]) // no star, include pkg path
+		if b.isPrimitiveType(fieldType.String()[1:]) {
+			prop.Type = &pType
+			prop.Format = b.jsonSchemaFormat(fieldType.String()[1:])
+			return jsonName, prop
+		}
+		prop.Ref = &pType
+		elemName := ""
+		if fieldType.Elem().Name() == "" {
+			elemName = modelName + "." + jsonName
+			prop.Ref = &elemName
+		}
+		b.addModel(fieldType.Elem(), elemName)
+	}
+	return jsonName, prop
+}
+
+func (b modelBuilder) getElementTypeName(modelName, jsonName string, t reflect.Type) string {
+	if t.Kind() == reflect.Ptr {
+		return t.String()[1:]
+	}
+	if t.Name() == "" {
+		return modelName + "." + jsonName
+	}
+	return b.keyFrom(t)
+}
+
+func (b modelBuilder) keyFrom(st reflect.Type) string {
+	key := st.String()
+	if len(st.Name()) == 0 { // unnamed type
+		// Swagger UI has special meaning for [
+		key = strings.Replace(key, "[]", "||", -1)
+	}
+	return key
+}
+
+// see also https://golang.org/ref/spec#Numeric_types
+func (b modelBuilder) isPrimitiveType(modelName string) bool {
+	if len(modelName) == 0 {
+		return false
+	}
+	return strings.Contains("uint uint8 uint16 uint32 uint64 int int8 int16 int32 int64 float32 float64 bool string byte rune time.Time", modelName)
+}
+
+// jsonNameOfField returns the name of the field as it should appear in JSON format
+// An empty string indicates that this field is not part of the JSON representation
+func (b modelBuilder) jsonNameOfField(field reflect.StructField) string {
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		s := strings.Split(jsonTag, ",")
+		if s[0] == "-" {
+			// empty name signals skip property
+			return ""
+		} else if s[0] != "" {
+			return s[0]
+		}
+	}
+	return field.Name
+}
+
+// see also http://json-schema.org/latest/json-schema-core.html#anchor8
+func (b modelBuilder) jsonSchemaType(modelName string) string {
+	schemaMap := map[string]string{
+		"uint":   "integer",
+		"uint8":  "integer",
+		"uint16": "integer",
+		"uint32": "integer",
+		"uint64": "integer",
+
+		"int":   "integer",
+		"int8":  "integer",
+		"int16": "integer",
+		"int32": "integer",
+		"int64": "integer",
+
+		"byte":      "integer",
+		"float64":   "number",
+		"float32":   "number",
+		"bool":      "boolean",
+		"time.Time": "string",
+	}
+	mapped, ok := schemaMap[modelName]
+	if !ok {
+		return modelName // use as is (custom or struct)
+	}
+	return mapped
+}
+
+func (b modelBuilder) jsonSchemaFormat(modelName string) string {
+	if b.Config != nil && b.Config.SchemaFormatHandler != nil {
+		if mapped := b.Config.SchemaFormatHandler(modelName); mapped != "" {
+			return mapped
+		}
+	}
+	schemaMap := map[string]string{
+		"int":        "int32",
+		"int32":      "int32",
+		"int64":      "int64",
+		"byte":       "byte",
+		"uint":       "integer",
+		"uint8":      "byte",
+		"float64":    "double",
+		"float32":    "float",
+		"time.Time":  "date-time",
+		"*time.Time": "date-time",
+	}
+	mapped, ok := schemaMap[modelName]
+	if !ok {
+		return "" // no format
+	}
+	return mapped
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/model_list.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/model_list.go
@@ -1,0 +1,86 @@
+package swagger
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// NamedModel associates a name with a Model (not using its Id)
+type NamedModel struct {
+	Name  string
+	Model Model
+}
+
+// ModelList encapsulates a list of NamedModel (association)
+type ModelList struct {
+	List []NamedModel
+}
+
+// Put adds or replaces a Model by its name
+func (l *ModelList) Put(name string, model Model) {
+	for i, each := range l.List {
+		if each.Name == name {
+			// replace
+			l.List[i] = NamedModel{name, model}
+			return
+		}
+	}
+	// add
+	l.List = append(l.List, NamedModel{name, model})
+}
+
+// At returns a Model by its name, ok is false if absent
+func (l *ModelList) At(name string) (m Model, ok bool) {
+	for _, each := range l.List {
+		if each.Name == name {
+			return each.Model, true
+		}
+	}
+	return m, false
+}
+
+// Do enumerates all the models, each with its assigned name
+func (l *ModelList) Do(block func(name string, value Model)) {
+	for _, each := range l.List {
+		block(each.Name, each.Model)
+	}
+}
+
+// MarshalJSON writes the ModelList as if it was a map[string]Model
+func (l ModelList) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	buf.WriteString("{\n")
+	for i, each := range l.List {
+		buf.WriteString("\"")
+		buf.WriteString(each.Name)
+		buf.WriteString("\": ")
+		encoder.Encode(each.Model)
+		if i < len(l.List)-1 {
+			buf.WriteString(",\n")
+		}
+	}
+	buf.WriteString("}")
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSON reads back a ModelList. This is an expensive operation.
+func (l *ModelList) UnmarshalJSON(data []byte) error {
+	raw := map[string]interface{}{}
+	json.NewDecoder(bytes.NewReader(data)).Decode(&raw)
+	for k, v := range raw {
+		// produces JSON bytes for each value
+		data, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		var m Model
+		json.NewDecoder(bytes.NewReader(data)).Decode(&m)
+		l.Put(k, m)
+	}
+	return nil
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/model_property_ext.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/model_property_ext.go
@@ -1,0 +1,81 @@
+package swagger
+
+import (
+	"reflect"
+	"strings"
+)
+
+func (prop *ModelProperty) setDescription(field reflect.StructField) {
+	if tag := field.Tag.Get("description"); tag != "" {
+		prop.Description = tag
+	}
+}
+
+func (prop *ModelProperty) setDefaultValue(field reflect.StructField) {
+	if tag := field.Tag.Get("default"); tag != "" {
+		prop.DefaultValue = Special(tag)
+	}
+}
+
+func (prop *ModelProperty) setEnumValues(field reflect.StructField) {
+	// We use | to separate the enum values.  This value is chosen
+	// since its unlikely to be useful in actual enumeration values.
+	if tag := field.Tag.Get("enum"); tag != "" {
+		prop.Enum = strings.Split(tag, "|")
+	}
+}
+
+func (prop *ModelProperty) setMaximum(field reflect.StructField) {
+	if tag := field.Tag.Get("maximum"); tag != "" {
+		prop.Maximum = tag
+	}
+}
+
+func (prop *ModelProperty) setType(field reflect.StructField) {
+	if tag := field.Tag.Get("type"); tag != "" {
+		// Check if the first two characters of the type tag are
+		// intended to emulate slice/array behaviour.
+		//
+		// If type is intended to be a slice/array then add the
+		// overriden type to the array item instead of the main property
+		if len(tag) > 2 && tag[0:2] == "[]" {
+			pType := "array"
+			prop.Type = &pType
+			prop.Items = new(Item)
+
+			iType := tag[2:]
+			prop.Items.Type = &iType
+			return
+		}
+
+		prop.Type = &tag
+	}
+}
+
+func (prop *ModelProperty) setMinimum(field reflect.StructField) {
+	if tag := field.Tag.Get("minimum"); tag != "" {
+		prop.Minimum = tag
+	}
+}
+
+func (prop *ModelProperty) setUniqueItems(field reflect.StructField) {
+	tag := field.Tag.Get("unique")
+	switch tag {
+	case "true":
+		v := true
+		prop.UniqueItems = &v
+	case "false":
+		v := false
+		prop.UniqueItems = &v
+	}
+}
+
+func (prop *ModelProperty) setPropertyMetadata(field reflect.StructField) {
+	prop.setDescription(field)
+	prop.setEnumValues(field)
+	prop.setMinimum(field)
+	prop.setMaximum(field)
+	prop.setUniqueItems(field)
+	prop.setDefaultValue(field)
+	prop.setType(field)
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/model_property_list.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/model_property_list.go
@@ -1,0 +1,87 @@
+package swagger
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// NamedModelProperty associates a name to a ModelProperty
+type NamedModelProperty struct {
+	Name     string
+	Property ModelProperty
+}
+
+// ModelPropertyList encapsulates a list of NamedModelProperty (association)
+type ModelPropertyList struct {
+	List []NamedModelProperty
+}
+
+// At returns the ModelPropety by its name unless absent, then ok is false
+func (l *ModelPropertyList) At(name string) (p ModelProperty, ok bool) {
+	for _, each := range l.List {
+		if each.Name == name {
+			return each.Property, true
+		}
+	}
+	return p, false
+}
+
+// Put adds or replaces a ModelProperty with this name
+func (l *ModelPropertyList) Put(name string, prop ModelProperty) {
+	// maybe replace existing
+	for i, each := range l.List {
+		if each.Name == name {
+			// replace
+			l.List[i] = NamedModelProperty{Name: name, Property: prop}
+			return
+		}
+	}
+	// add
+	l.List = append(l.List, NamedModelProperty{Name: name, Property: prop})
+}
+
+// Do enumerates all the properties, each with its assigned name
+func (l *ModelPropertyList) Do(block func(name string, value ModelProperty)) {
+	for _, each := range l.List {
+		block(each.Name, each.Property)
+	}
+}
+
+// MarshalJSON writes the ModelPropertyList as if it was a map[string]ModelProperty
+func (l ModelPropertyList) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	buf.WriteString("{\n")
+	for i, each := range l.List {
+		buf.WriteString("\"")
+		buf.WriteString(each.Name)
+		buf.WriteString("\": ")
+		encoder.Encode(each.Property)
+		if i < len(l.List)-1 {
+			buf.WriteString(",\n")
+		}
+	}
+	buf.WriteString("}")
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSON reads back a ModelPropertyList. This is an expensive operation.
+func (l *ModelPropertyList) UnmarshalJSON(data []byte) error {
+	raw := map[string]interface{}{}
+	json.NewDecoder(bytes.NewReader(data)).Decode(&raw)
+	for k, v := range raw {
+		// produces JSON bytes for each value
+		data, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		var m ModelProperty
+		json.NewDecoder(bytes.NewReader(data)).Decode(&m)
+		l.Put(k, m)
+	}
+	return nil
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/ordered_route_map.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/ordered_route_map.go
@@ -1,0 +1,36 @@
+package swagger
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import "github.com/emicklei/go-restful"
+
+type orderedRouteMap struct {
+	elements map[string][]restful.Route
+	keys     []string
+}
+
+func newOrderedRouteMap() *orderedRouteMap {
+	return &orderedRouteMap{
+		elements: map[string][]restful.Route{},
+		keys:     []string{},
+	}
+}
+
+func (o *orderedRouteMap) Add(key string, route restful.Route) {
+	routes, ok := o.elements[key]
+	if ok {
+		routes = append(routes, route)
+		o.elements[key] = routes
+		return
+	}
+	o.elements[key] = []restful.Route{route}
+	o.keys = append(o.keys, key)
+}
+
+func (o *orderedRouteMap) Do(block func(key string, routes []restful.Route)) {
+	for _, k := range o.keys {
+		block(k, o.elements[k])
+	}
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/swagger.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/swagger.go
@@ -1,0 +1,185 @@
+// Package swagger implements the structures of the Swagger
+// https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md
+package swagger
+
+const swaggerVersion = "1.2"
+
+// 4.3.3 Data Type Fields
+type DataTypeFields struct {
+	Type         *string  `json:"type,omitempty"` // if Ref not used
+	Ref          *string  `json:"$ref,omitempty"` // if Type not used
+	Format       string   `json:"format,omitempty"`
+	DefaultValue Special  `json:"defaultValue,omitempty"`
+	Enum         []string `json:"enum,omitempty"`
+	Minimum      string   `json:"minimum,omitempty"`
+	Maximum      string   `json:"maximum,omitempty"`
+	Items        *Item    `json:"items,omitempty"`
+	UniqueItems  *bool    `json:"uniqueItems,omitempty"`
+}
+
+type Special string
+
+// 4.3.4 Items Object
+type Item struct {
+	Type   *string `json:"type,omitempty"`
+	Ref    *string `json:"$ref,omitempty"`
+	Format string  `json:"format,omitempty"`
+}
+
+// 5.1 Resource Listing
+type ResourceListing struct {
+	SwaggerVersion string          `json:"swaggerVersion"` // e.g 1.2
+	Apis           []Resource      `json:"apis"`
+	ApiVersion     string          `json:"apiVersion"`
+	Info           Info            `json:"info"`
+	Authorizations []Authorization `json:"authorizations,omitempty"`
+}
+
+// 5.1.2 Resource Object
+type Resource struct {
+	Path        string `json:"path"` // relative or absolute, must start with /
+	Description string `json:"description"`
+}
+
+// 5.1.3 Info Object
+type Info struct {
+	Title             string `json:"title"`
+	Description       string `json:"description"`
+	TermsOfServiceUrl string `json:"termsOfServiceUrl,omitempty"`
+	Contact           string `json:"contact,omitempty"`
+	License           string `json:"license,omitempty"`
+	LicenseUrl        string `json:"licenseUrl,omitempty"`
+}
+
+// 5.1.5
+type Authorization struct {
+	Type       string      `json:"type"`
+	PassAs     string      `json:"passAs"`
+	Keyname    string      `json:"keyname"`
+	Scopes     []Scope     `json:"scopes"`
+	GrantTypes []GrantType `json:"grandTypes"`
+}
+
+// 5.1.6, 5.2.11
+type Scope struct {
+	// Required. The name of the scope.
+	Scope string `json:"scope"`
+	// Recommended. A short description of the scope.
+	Description string `json:"description"`
+}
+
+// 5.1.7
+type GrantType struct {
+	Implicit          Implicit          `json:"implicit"`
+	AuthorizationCode AuthorizationCode `json:"authorization_code"`
+}
+
+// 5.1.8 Implicit Object
+type Implicit struct {
+	// Required. The login endpoint definition.
+	loginEndpoint LoginEndpoint `json:"loginEndpoint"`
+	// An optional alternative name to standard "access_token" OAuth2 parameter.
+	TokenName string `json:"tokenName"`
+}
+
+// 5.1.9 Authorization Code Object
+type AuthorizationCode struct {
+	TokenRequestEndpoint TokenRequestEndpoint `json:"tokenRequestEndpoint"`
+	TokenEndpoint        TokenEndpoint        `json:"tokenEndpoint"`
+}
+
+// 5.1.10 Login Endpoint Object
+type LoginEndpoint struct {
+	// Required. The URL of the authorization endpoint for the implicit grant flow. The value SHOULD be in a URL format.
+	Url string `json:"url"`
+}
+
+// 5.1.11 Token Request Endpoint Object
+type TokenRequestEndpoint struct {
+	// Required. The URL of the authorization endpoint for the authentication code grant flow. The value SHOULD be in a URL format.
+	Url string `json:"url"`
+	// An optional alternative name to standard "client_id" OAuth2 parameter.
+	ClientIdName string `json:"clientIdName"`
+	// An optional alternative name to the standard "client_secret" OAuth2 parameter.
+	ClientSecretName string `json:"clientSecretName"`
+}
+
+// 5.1.12 Token Endpoint Object
+type TokenEndpoint struct {
+	// Required. The URL of the token endpoint for the authentication code grant flow. The value SHOULD be in a URL format.
+	Url string `json:"url"`
+	// An optional alternative name to standard "access_token" OAuth2 parameter.
+	TokenName string `json:"tokenName"`
+}
+
+// 5.2 API Declaration
+type ApiDeclaration struct {
+	SwaggerVersion string          `json:"swaggerVersion"`
+	ApiVersion     string          `json:"apiVersion"`
+	BasePath       string          `json:"basePath"`
+	ResourcePath   string          `json:"resourcePath"` // must start with /
+	Info           Info            `json:"info"`
+	Apis           []Api           `json:"apis,omitempty"`
+	Models         ModelList       `json:"models,omitempty"`
+	Produces       []string        `json:"produces,omitempty"`
+	Consumes       []string        `json:"consumes,omitempty"`
+	Authorizations []Authorization `json:"authorizations,omitempty"`
+}
+
+// 5.2.2 API Object
+type Api struct {
+	Path        string      `json:"path"` // relative or absolute, must start with /
+	Description string      `json:"description"`
+	Operations  []Operation `json:"operations,omitempty"`
+}
+
+// 5.2.3 Operation Object
+type Operation struct {
+	DataTypeFields
+	Method           string            `json:"method"`
+	Summary          string            `json:"summary,omitempty"`
+	Notes            string            `json:"notes,omitempty"`
+	Nickname         string            `json:"nickname"`
+	Authorizations   []Authorization   `json:"authorizations,omitempty"`
+	Parameters       []Parameter       `json:"parameters"`
+	ResponseMessages []ResponseMessage `json:"responseMessages,omitempty"` // optional
+	Produces         []string          `json:"produces,omitempty"`
+	Consumes         []string          `json:"consumes,omitempty"`
+	Deprecated       string            `json:"deprecated,omitempty"`
+}
+
+// 5.2.4 Parameter Object
+type Parameter struct {
+	DataTypeFields
+	ParamType     string `json:"paramType"` // path,query,body,header,form
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	Required      bool   `json:"required"`
+	AllowMultiple bool   `json:"allowMultiple"`
+}
+
+// 5.2.5 Response Message Object
+type ResponseMessage struct {
+	Code          int    `json:"code"`
+	Message       string `json:"message"`
+	ResponseModel string `json:"responseModel,omitempty"`
+}
+
+// 5.2.6, 5.2.7 Models Object
+type Model struct {
+	Id            string            `json:"id"`
+	Description   string            `json:"description,omitempty"`
+	Required      []string          `json:"required,omitempty"`
+	Properties    ModelPropertyList `json:"properties"`
+	SubTypes      []string          `json:"subTypes,omitempty"`
+	Discriminator string            `json:"discriminator,omitempty"`
+}
+
+// 5.2.8 Properties Object
+type ModelProperty struct {
+	DataTypeFields
+	Description string `json:"description,omitempty"`
+}
+
+// 5.2.10
+type Authorizations map[string]Authorization

--- a/vendor/github.com/emicklei/go-restful/swagger/swagger_builder.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/swagger_builder.go
@@ -1,0 +1,21 @@
+package swagger
+
+type SwaggerBuilder struct {
+	SwaggerService
+}
+
+func NewSwaggerBuilder(config Config) *SwaggerBuilder {
+	return &SwaggerBuilder{*newSwaggerService(config)}
+}
+
+func (sb SwaggerBuilder) ProduceListing() ResourceListing {
+	return sb.SwaggerService.produceListing()
+}
+
+func (sb SwaggerBuilder) ProduceAllDeclarations() map[string]ApiDeclaration {
+	return sb.SwaggerService.produceAllDeclarations()
+}
+
+func (sb SwaggerBuilder) ProduceDeclarations(route string) (*ApiDeclaration, bool) {
+	return sb.SwaggerService.produceDeclarations(route)
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/swagger_webservice.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/swagger_webservice.go
@@ -1,0 +1,440 @@
+package swagger
+
+import (
+	"fmt"
+
+	"github.com/emicklei/go-restful"
+	// "github.com/emicklei/hopwatch"
+	"net/http"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/emicklei/go-restful/log"
+)
+
+type SwaggerService struct {
+	config            Config
+	apiDeclarationMap *ApiDeclarationList
+}
+
+func newSwaggerService(config Config) *SwaggerService {
+	sws := &SwaggerService{
+		config:            config,
+		apiDeclarationMap: new(ApiDeclarationList)}
+
+	// Build all ApiDeclarations
+	for _, each := range config.WebServices {
+		rootPath := each.RootPath()
+		// skip the api service itself
+		if rootPath != config.ApiPath {
+			if rootPath == "" || rootPath == "/" {
+				// use routes
+				for _, route := range each.Routes() {
+					entry := staticPathFromRoute(route)
+					_, exists := sws.apiDeclarationMap.At(entry)
+					if !exists {
+						sws.apiDeclarationMap.Put(entry, sws.composeDeclaration(each, entry))
+					}
+				}
+			} else { // use root path
+				sws.apiDeclarationMap.Put(each.RootPath(), sws.composeDeclaration(each, each.RootPath()))
+			}
+		}
+	}
+
+	// if specified then call the PostBuilderHandler
+	if config.PostBuildHandler != nil {
+		config.PostBuildHandler(sws.apiDeclarationMap)
+	}
+	return sws
+}
+
+// LogInfo is the function that is called when this package needs to log. It defaults to log.Printf
+var LogInfo = func(format string, v ...interface{}) {
+	// use the restful package-wide logger
+	log.Printf(format, v...)
+}
+
+// InstallSwaggerService add the WebService that provides the API documentation of all services
+// conform the Swagger documentation specifcation. (https://github.com/wordnik/swagger-core/wiki).
+func InstallSwaggerService(aSwaggerConfig Config) {
+	RegisterSwaggerService(aSwaggerConfig, restful.DefaultContainer)
+}
+
+// RegisterSwaggerService add the WebService that provides the API documentation of all services
+// conform the Swagger documentation specifcation. (https://github.com/wordnik/swagger-core/wiki).
+func RegisterSwaggerService(config Config, wsContainer *restful.Container) {
+	sws := newSwaggerService(config)
+	ws := new(restful.WebService)
+	ws.Path(config.ApiPath)
+	ws.Produces(restful.MIME_JSON)
+	if config.DisableCORS {
+		ws.Filter(enableCORS)
+	}
+	ws.Route(ws.GET("/").To(sws.getListing))
+	ws.Route(ws.GET("/{a}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}/{c}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}/{c}/{d}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}/{c}/{d}/{e}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}/{c}/{d}/{e}/{f}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}/{c}/{d}/{e}/{f}/{g}").To(sws.getDeclarations))
+	LogInfo("[restful/swagger] listing is available at %v%v", config.WebServicesUrl, config.ApiPath)
+	wsContainer.Add(ws)
+
+	// Check paths for UI serving
+	if config.StaticHandler == nil && config.SwaggerFilePath != "" && config.SwaggerPath != "" {
+		swaggerPathSlash := config.SwaggerPath
+		// path must end with slash /
+		if "/" != config.SwaggerPath[len(config.SwaggerPath)-1:] {
+			LogInfo("[restful/swagger] use corrected SwaggerPath ; must end with slash (/)")
+			swaggerPathSlash += "/"
+		}
+
+		LogInfo("[restful/swagger] %v%v is mapped to folder %v", config.WebServicesUrl, swaggerPathSlash, config.SwaggerFilePath)
+		wsContainer.Handle(swaggerPathSlash, http.StripPrefix(swaggerPathSlash, http.FileServer(http.Dir(config.SwaggerFilePath))))
+
+		//if we define a custom static handler use it
+	} else if config.StaticHandler != nil && config.SwaggerPath != "" {
+		swaggerPathSlash := config.SwaggerPath
+		// path must end with slash /
+		if "/" != config.SwaggerPath[len(config.SwaggerPath)-1:] {
+			LogInfo("[restful/swagger] use corrected SwaggerFilePath ; must end with slash (/)")
+			swaggerPathSlash += "/"
+
+		}
+		LogInfo("[restful/swagger] %v%v is mapped to custom Handler %T", config.WebServicesUrl, swaggerPathSlash, config.StaticHandler)
+		wsContainer.Handle(swaggerPathSlash, config.StaticHandler)
+
+	} else {
+		LogInfo("[restful/swagger] Swagger(File)Path is empty ; no UI is served")
+	}
+}
+
+func staticPathFromRoute(r restful.Route) string {
+	static := r.Path
+	bracket := strings.Index(static, "{")
+	if bracket <= 1 { // result cannot be empty
+		return static
+	}
+	if bracket != -1 {
+		static = r.Path[:bracket]
+	}
+	if strings.HasSuffix(static, "/") {
+		return static[:len(static)-1]
+	} else {
+		return static
+	}
+}
+
+func enableCORS(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	if origin := req.HeaderParameter(restful.HEADER_Origin); origin != "" {
+		// prevent duplicate header
+		if len(resp.Header().Get(restful.HEADER_AccessControlAllowOrigin)) == 0 {
+			resp.AddHeader(restful.HEADER_AccessControlAllowOrigin, origin)
+		}
+	}
+	chain.ProcessFilter(req, resp)
+}
+
+func (sws SwaggerService) getListing(req *restful.Request, resp *restful.Response) {
+	listing := sws.produceListing()
+	resp.WriteAsJson(listing)
+}
+
+func (sws SwaggerService) produceListing() ResourceListing {
+	listing := ResourceListing{SwaggerVersion: swaggerVersion, ApiVersion: sws.config.ApiVersion, Info: sws.config.Info}
+	sws.apiDeclarationMap.Do(func(k string, v ApiDeclaration) {
+		ref := Resource{Path: k}
+		if len(v.Apis) > 0 { // use description of first (could still be empty)
+			ref.Description = v.Apis[0].Description
+		}
+		listing.Apis = append(listing.Apis, ref)
+	})
+	return listing
+}
+
+func (sws SwaggerService) getDeclarations(req *restful.Request, resp *restful.Response) {
+	decl, ok := sws.produceDeclarations(composeRootPath(req))
+	if !ok {
+		resp.WriteErrorString(http.StatusNotFound, "ApiDeclaration not found")
+		return
+	}
+	// unless WebServicesUrl is given
+	if len(sws.config.WebServicesUrl) == 0 {
+		// update base path from the actual request
+		// TODO how to detect https? assume http for now
+		var host string
+		// X-Forwarded-Host or Host or Request.Host
+		hostvalues, ok := req.Request.Header["X-Forwarded-Host"] // apache specific?
+		if !ok || len(hostvalues) == 0 {
+			forwarded, ok := req.Request.Header["Host"] // without reverse-proxy
+			if !ok || len(forwarded) == 0 {
+				// fallback to Host field
+				host = req.Request.Host
+			} else {
+				host = forwarded[0]
+			}
+		} else {
+			host = hostvalues[0]
+		}
+		// inspect Referer for the scheme (http vs https)
+		scheme := "http"
+		if referer := req.Request.Header["Referer"]; len(referer) > 0 {
+			if strings.HasPrefix(referer[0], "https") {
+				scheme = "https"
+			}
+		}
+		decl.BasePath = fmt.Sprintf("%s://%s", scheme, host)
+	}
+	resp.WriteAsJson(decl)
+}
+
+func (sws SwaggerService) produceAllDeclarations() map[string]ApiDeclaration {
+	decls := map[string]ApiDeclaration{}
+	sws.apiDeclarationMap.Do(func(k string, v ApiDeclaration) {
+		decls[k] = v
+	})
+	return decls
+}
+
+func (sws SwaggerService) produceDeclarations(route string) (*ApiDeclaration, bool) {
+	decl, ok := sws.apiDeclarationMap.At(route)
+	if !ok {
+		return nil, false
+	}
+	decl.BasePath = sws.config.WebServicesUrl
+	return &decl, true
+}
+
+// composeDeclaration uses all routes and parameters to create a ApiDeclaration
+func (sws SwaggerService) composeDeclaration(ws *restful.WebService, pathPrefix string) ApiDeclaration {
+	decl := ApiDeclaration{
+		SwaggerVersion: swaggerVersion,
+		BasePath:       sws.config.WebServicesUrl,
+		ResourcePath:   pathPrefix,
+		Models:         ModelList{},
+		ApiVersion:     ws.Version()}
+
+	// collect any path parameters
+	rootParams := []Parameter{}
+	for _, param := range ws.PathParameters() {
+		rootParams = append(rootParams, asSwaggerParameter(param.Data()))
+	}
+	// aggregate by path
+	pathToRoutes := newOrderedRouteMap()
+	for _, other := range ws.Routes() {
+		if strings.HasPrefix(other.Path, pathPrefix) {
+			pathToRoutes.Add(other.Path, other)
+		}
+	}
+	pathToRoutes.Do(func(path string, routes []restful.Route) {
+		api := Api{Path: strings.TrimSuffix(withoutWildcard(path), "/"), Description: ws.Documentation()}
+		voidString := "void"
+		for _, route := range routes {
+			operation := Operation{
+				Method:  route.Method,
+				Summary: route.Doc,
+				Notes:   route.Notes,
+				// Type gets overwritten if there is a write sample
+				DataTypeFields:   DataTypeFields{Type: &voidString},
+				Parameters:       []Parameter{},
+				Nickname:         route.Operation,
+				ResponseMessages: composeResponseMessages(route, &decl, &sws.config)}
+
+			operation.Consumes = route.Consumes
+			operation.Produces = route.Produces
+
+			// share root params if any
+			for _, swparam := range rootParams {
+				operation.Parameters = append(operation.Parameters, swparam)
+			}
+			// route specific params
+			for _, param := range route.ParameterDocs {
+				operation.Parameters = append(operation.Parameters, asSwaggerParameter(param.Data()))
+			}
+
+			sws.addModelsFromRouteTo(&operation, route, &decl)
+			api.Operations = append(api.Operations, operation)
+		}
+		decl.Apis = append(decl.Apis, api)
+	})
+	return decl
+}
+
+func withoutWildcard(path string) string {
+	if strings.HasSuffix(path, ":*}") {
+		return path[0:len(path)-3] + "}"
+	}
+	return path
+}
+
+// composeResponseMessages takes the ResponseErrors (if any) and creates ResponseMessages from them.
+func composeResponseMessages(route restful.Route, decl *ApiDeclaration, config *Config) (messages []ResponseMessage) {
+	if route.ResponseErrors == nil {
+		return messages
+	}
+	// sort by code
+	codes := sort.IntSlice{}
+	for code := range route.ResponseErrors {
+		codes = append(codes, code)
+	}
+	codes.Sort()
+	for _, code := range codes {
+		each := route.ResponseErrors[code]
+		message := ResponseMessage{
+			Code:    code,
+			Message: each.Message,
+		}
+		if each.Model != nil {
+			st := reflect.TypeOf(each.Model)
+			isCollection, st := detectCollectionType(st)
+			modelName := modelBuilder{}.keyFrom(st)
+			if isCollection {
+				modelName = "array[" + modelName + "]"
+			}
+			modelBuilder{Models: &decl.Models, Config: config}.addModel(st, "")
+			// reference the model
+			message.ResponseModel = modelName
+		}
+		messages = append(messages, message)
+	}
+	return
+}
+
+// addModelsFromRoute takes any read or write sample from the Route and creates a Swagger model from it.
+func (sws SwaggerService) addModelsFromRouteTo(operation *Operation, route restful.Route, decl *ApiDeclaration) {
+	if route.ReadSample != nil {
+		sws.addModelFromSampleTo(operation, false, route.ReadSample, &decl.Models)
+	}
+	if route.WriteSample != nil {
+		sws.addModelFromSampleTo(operation, true, route.WriteSample, &decl.Models)
+	}
+}
+
+func detectCollectionType(st reflect.Type) (bool, reflect.Type) {
+	isCollection := false
+	if st.Kind() == reflect.Slice || st.Kind() == reflect.Array {
+		st = st.Elem()
+		isCollection = true
+	} else {
+		if st.Kind() == reflect.Ptr {
+			if st.Elem().Kind() == reflect.Slice || st.Elem().Kind() == reflect.Array {
+				st = st.Elem().Elem()
+				isCollection = true
+			}
+		}
+	}
+	return isCollection, st
+}
+
+// addModelFromSample creates and adds (or overwrites) a Model from a sample resource
+func (sws SwaggerService) addModelFromSampleTo(operation *Operation, isResponse bool, sample interface{}, models *ModelList) {
+	if isResponse {
+		type_, items := asDataType(sample, &sws.config)
+		operation.Type = type_
+		operation.Items = items
+	}
+	modelBuilder{Models: models, Config: &sws.config}.addModelFrom(sample)
+}
+
+func asSwaggerParameter(param restful.ParameterData) Parameter {
+	return Parameter{
+		DataTypeFields: DataTypeFields{
+			Type:         &param.DataType,
+			Format:       asFormat(param.DataType, param.DataFormat),
+			DefaultValue: Special(param.DefaultValue),
+		},
+		Name:        param.Name,
+		Description: param.Description,
+		ParamType:   asParamType(param.Kind),
+
+		Required: param.Required}
+}
+
+// Between 1..7 path parameters is supported
+func composeRootPath(req *restful.Request) string {
+	path := "/" + req.PathParameter("a")
+	b := req.PathParameter("b")
+	if b == "" {
+		return path
+	}
+	path = path + "/" + b
+	c := req.PathParameter("c")
+	if c == "" {
+		return path
+	}
+	path = path + "/" + c
+	d := req.PathParameter("d")
+	if d == "" {
+		return path
+	}
+	path = path + "/" + d
+	e := req.PathParameter("e")
+	if e == "" {
+		return path
+	}
+	path = path + "/" + e
+	f := req.PathParameter("f")
+	if f == "" {
+		return path
+	}
+	path = path + "/" + f
+	g := req.PathParameter("g")
+	if g == "" {
+		return path
+	}
+	return path + "/" + g
+}
+
+func asFormat(dataType string, dataFormat string) string {
+	if dataFormat != "" {
+		return dataFormat
+	}
+	return "" // TODO
+}
+
+func asParamType(kind int) string {
+	switch {
+	case kind == restful.PathParameterKind:
+		return "path"
+	case kind == restful.QueryParameterKind:
+		return "query"
+	case kind == restful.BodyParameterKind:
+		return "body"
+	case kind == restful.HeaderParameterKind:
+		return "header"
+	case kind == restful.FormParameterKind:
+		return "form"
+	}
+	return ""
+}
+
+func asDataType(any interface{}, config *Config) (*string, *Item) {
+	// If it's not a collection, return the suggested model name
+	st := reflect.TypeOf(any)
+	isCollection, st := detectCollectionType(st)
+	modelName := modelBuilder{}.keyFrom(st)
+	// if it's not a collection we are done
+	if !isCollection {
+		return &modelName, nil
+	}
+
+	// XXX: This is not very elegant
+	// We create an Item object referring to the given model
+	models := ModelList{}
+	mb := modelBuilder{Models: &models, Config: config}
+	mb.addModelFrom(any)
+
+	elemTypeName := mb.getElementTypeName(modelName, "", st)
+	item := new(Item)
+	if mb.isPrimitiveType(elemTypeName) {
+		mapped := mb.jsonSchemaType(elemTypeName)
+		item.Type = &mapped
+	} else {
+		item.Ref = &elemTypeName
+	}
+	tmp := "array"
+	return &tmp, item
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/test_package/struct.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/test_package/struct.go
@@ -1,0 +1,5 @@
+package test_package
+
+type TestStruct struct {
+	TestField string
+}

--- a/vendor/github.com/emicklei/go-restful/web_service.go
+++ b/vendor/github.com/emicklei/go-restful/web_service.go
@@ -1,0 +1,268 @@
+package restful
+
+import (
+	"errors"
+	"os"
+	"sync"
+
+	"github.com/emicklei/go-restful/log"
+)
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+// WebService holds a collection of Route values that bind a Http Method + URL Path to a function.
+type WebService struct {
+	rootPath       string
+	pathExpr       *pathExpression // cached compilation of rootPath as RegExp
+	routes         []Route
+	produces       []string
+	consumes       []string
+	pathParameters []*Parameter
+	filters        []FilterFunction
+	documentation  string
+	apiVersion     string
+
+	dynamicRoutes bool
+
+	// protects 'routes' if dynamic routes are enabled
+	routesLock sync.RWMutex
+}
+
+func (w *WebService) SetDynamicRoutes(enable bool) {
+	w.dynamicRoutes = enable
+}
+
+// compilePathExpression ensures that the path is compiled into a RegEx for those routers that need it.
+func (w *WebService) compilePathExpression() {
+	compiled, err := newPathExpression(w.rootPath)
+	if err != nil {
+		log.Printf("[restful] invalid path:%s because:%v", w.rootPath, err)
+		os.Exit(1)
+	}
+	w.pathExpr = compiled
+}
+
+// ApiVersion sets the API version for documentation purposes.
+func (w *WebService) ApiVersion(apiVersion string) *WebService {
+	w.apiVersion = apiVersion
+	return w
+}
+
+// Version returns the API version for documentation purposes.
+func (w *WebService) Version() string { return w.apiVersion }
+
+// Path specifies the root URL template path of the WebService.
+// All Routes will be relative to this path.
+func (w *WebService) Path(root string) *WebService {
+	w.rootPath = root
+	if len(w.rootPath) == 0 {
+		w.rootPath = "/"
+	}
+	w.compilePathExpression()
+	return w
+}
+
+// Param adds a PathParameter to document parameters used in the root path.
+func (w *WebService) Param(parameter *Parameter) *WebService {
+	if w.pathParameters == nil {
+		w.pathParameters = []*Parameter{}
+	}
+	w.pathParameters = append(w.pathParameters, parameter)
+	return w
+}
+
+// PathParameter creates a new Parameter of kind Path for documentation purposes.
+// It is initialized as required with string as its DataType.
+func (w *WebService) PathParameter(name, description string) *Parameter {
+	return PathParameter(name, description)
+}
+
+// PathParameter creates a new Parameter of kind Path for documentation purposes.
+// It is initialized as required with string as its DataType.
+func PathParameter(name, description string) *Parameter {
+	p := &Parameter{&ParameterData{Name: name, Description: description, Required: true, DataType: "string"}}
+	p.bePath()
+	return p
+}
+
+// QueryParameter creates a new Parameter of kind Query for documentation purposes.
+// It is initialized as not required with string as its DataType.
+func (w *WebService) QueryParameter(name, description string) *Parameter {
+	return QueryParameter(name, description)
+}
+
+// QueryParameter creates a new Parameter of kind Query for documentation purposes.
+// It is initialized as not required with string as its DataType.
+func QueryParameter(name, description string) *Parameter {
+	p := &Parameter{&ParameterData{Name: name, Description: description, Required: false, DataType: "string"}}
+	p.beQuery()
+	return p
+}
+
+// BodyParameter creates a new Parameter of kind Body for documentation purposes.
+// It is initialized as required without a DataType.
+func (w *WebService) BodyParameter(name, description string) *Parameter {
+	return BodyParameter(name, description)
+}
+
+// BodyParameter creates a new Parameter of kind Body for documentation purposes.
+// It is initialized as required without a DataType.
+func BodyParameter(name, description string) *Parameter {
+	p := &Parameter{&ParameterData{Name: name, Description: description, Required: true}}
+	p.beBody()
+	return p
+}
+
+// HeaderParameter creates a new Parameter of kind (Http) Header for documentation purposes.
+// It is initialized as not required with string as its DataType.
+func (w *WebService) HeaderParameter(name, description string) *Parameter {
+	return HeaderParameter(name, description)
+}
+
+// HeaderParameter creates a new Parameter of kind (Http) Header for documentation purposes.
+// It is initialized as not required with string as its DataType.
+func HeaderParameter(name, description string) *Parameter {
+	p := &Parameter{&ParameterData{Name: name, Description: description, Required: false, DataType: "string"}}
+	p.beHeader()
+	return p
+}
+
+// FormParameter creates a new Parameter of kind Form (using application/x-www-form-urlencoded) for documentation purposes.
+// It is initialized as required with string as its DataType.
+func (w *WebService) FormParameter(name, description string) *Parameter {
+	return FormParameter(name, description)
+}
+
+// FormParameter creates a new Parameter of kind Form (using application/x-www-form-urlencoded) for documentation purposes.
+// It is initialized as required with string as its DataType.
+func FormParameter(name, description string) *Parameter {
+	p := &Parameter{&ParameterData{Name: name, Description: description, Required: false, DataType: "string"}}
+	p.beForm()
+	return p
+}
+
+// Route creates a new Route using the RouteBuilder and add to the ordered list of Routes.
+func (w *WebService) Route(builder *RouteBuilder) *WebService {
+	w.routesLock.Lock()
+	defer w.routesLock.Unlock()
+	builder.copyDefaults(w.produces, w.consumes)
+	w.routes = append(w.routes, builder.Build())
+	return w
+}
+
+// RemoveRoute removes the specified route, looks for something that matches 'path' and 'method'
+func (w *WebService) RemoveRoute(path, method string) error {
+	if !w.dynamicRoutes {
+		return errors.New("dynamic routes are not enabled.")
+	}
+	w.routesLock.Lock()
+	defer w.routesLock.Unlock()
+	newRoutes := make([]Route, (len(w.routes) - 1))
+	current := 0
+	for ix := range w.routes {
+		if w.routes[ix].Method == method && w.routes[ix].Path == path {
+			continue
+		}
+		newRoutes[current] = w.routes[ix]
+		current = current + 1
+	}
+	w.routes = newRoutes
+	return nil
+}
+
+// Method creates a new RouteBuilder and initialize its http method
+func (w *WebService) Method(httpMethod string) *RouteBuilder {
+	return new(RouteBuilder).servicePath(w.rootPath).Method(httpMethod)
+}
+
+// Produces specifies that this WebService can produce one or more MIME types.
+// Http requests must have one of these values set for the Accept header.
+func (w *WebService) Produces(contentTypes ...string) *WebService {
+	w.produces = contentTypes
+	return w
+}
+
+// Consumes specifies that this WebService can consume one or more MIME types.
+// Http requests must have one of these values set for the Content-Type header.
+func (w *WebService) Consumes(accepts ...string) *WebService {
+	w.consumes = accepts
+	return w
+}
+
+// Routes returns the Routes associated with this WebService
+func (w *WebService) Routes() []Route {
+	if !w.dynamicRoutes {
+		return w.routes
+	}
+	// Make a copy of the array to prevent concurrency problems
+	w.routesLock.RLock()
+	defer w.routesLock.RUnlock()
+	result := make([]Route, len(w.routes))
+	for ix := range w.routes {
+		result[ix] = w.routes[ix]
+	}
+	return result
+}
+
+// RootPath returns the RootPath associated with this WebService. Default "/"
+func (w *WebService) RootPath() string {
+	return w.rootPath
+}
+
+// PathParameters return the path parameter names for (shared amoung its Routes)
+func (w *WebService) PathParameters() []*Parameter {
+	return w.pathParameters
+}
+
+// Filter adds a filter function to the chain of filters applicable to all its Routes
+func (w *WebService) Filter(filter FilterFunction) *WebService {
+	w.filters = append(w.filters, filter)
+	return w
+}
+
+// Doc is used to set the documentation of this service.
+func (w *WebService) Doc(plainText string) *WebService {
+	w.documentation = plainText
+	return w
+}
+
+// Documentation returns it.
+func (w *WebService) Documentation() string {
+	return w.documentation
+}
+
+/*
+	Convenience methods
+*/
+
+// HEAD is a shortcut for .Method("HEAD").Path(subPath)
+func (w *WebService) HEAD(subPath string) *RouteBuilder {
+	return new(RouteBuilder).servicePath(w.rootPath).Method("HEAD").Path(subPath)
+}
+
+// GET is a shortcut for .Method("GET").Path(subPath)
+func (w *WebService) GET(subPath string) *RouteBuilder {
+	return new(RouteBuilder).servicePath(w.rootPath).Method("GET").Path(subPath)
+}
+
+// POST is a shortcut for .Method("POST").Path(subPath)
+func (w *WebService) POST(subPath string) *RouteBuilder {
+	return new(RouteBuilder).servicePath(w.rootPath).Method("POST").Path(subPath)
+}
+
+// PUT is a shortcut for .Method("PUT").Path(subPath)
+func (w *WebService) PUT(subPath string) *RouteBuilder {
+	return new(RouteBuilder).servicePath(w.rootPath).Method("PUT").Path(subPath)
+}
+
+// PATCH is a shortcut for .Method("PATCH").Path(subPath)
+func (w *WebService) PATCH(subPath string) *RouteBuilder {
+	return new(RouteBuilder).servicePath(w.rootPath).Method("PATCH").Path(subPath)
+}
+
+// DELETE is a shortcut for .Method("DELETE").Path(subPath)
+func (w *WebService) DELETE(subPath string) *RouteBuilder {
+	return new(RouteBuilder).servicePath(w.rootPath).Method("DELETE").Path(subPath)
+}

--- a/vendor/github.com/emicklei/go-restful/web_service_container.go
+++ b/vendor/github.com/emicklei/go-restful/web_service_container.go
@@ -1,0 +1,39 @@
+package restful
+
+// Copyright 2013 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"net/http"
+)
+
+// DefaultContainer is a restful.Container that uses http.DefaultServeMux
+var DefaultContainer *Container
+
+func init() {
+	DefaultContainer = NewContainer()
+	DefaultContainer.ServeMux = http.DefaultServeMux
+}
+
+// If set the true then panics will not be caught to return HTTP 500.
+// In that case, Route functions are responsible for handling any error situation.
+// Default value is false = recover from panics. This has performance implications.
+// OBSOLETE ; use restful.DefaultContainer.DoNotRecover(true)
+var DoNotRecover = false
+
+// Add registers a new WebService add it to the DefaultContainer.
+func Add(service *WebService) {
+	DefaultContainer.Add(service)
+}
+
+// Filter appends a container FilterFunction from the DefaultContainer.
+// These are called before dispatching a http.Request to a WebService.
+func Filter(filter FilterFunction) {
+	DefaultContainer.Filter(filter)
+}
+
+// RegisteredWebServices returns the collections of WebServices from the DefaultContainer
+func RegisteredWebServices() []*WebService {
+	return DefaultContainer.RegisteredWebServices()
+}

--- a/vendor/github.com/gorilla/schema/LICENSE
+++ b/vendor/github.com/gorilla/schema/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 Rodrigo Moraes. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+	 * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+	 * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+	 * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/gorilla/schema/cache.go
+++ b/vendor/github.com/gorilla/schema/cache.go
@@ -1,0 +1,261 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schema
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var invalidPath = errors.New("schema: invalid path")
+
+// newCache returns a new cache.
+func newCache() *cache {
+	c := cache{
+		m:       make(map[reflect.Type]*structInfo),
+		conv:    make(map[reflect.Kind]Converter),
+		regconv: make(map[reflect.Type]Converter),
+		tag:     "schema",
+	}
+	for k, v := range converters {
+		c.conv[k] = v
+	}
+	return &c
+}
+
+// cache caches meta-data about a struct.
+type cache struct {
+	l       sync.RWMutex
+	m       map[reflect.Type]*structInfo
+	conv    map[reflect.Kind]Converter
+	regconv map[reflect.Type]Converter
+	tag     string
+}
+
+// parsePath parses a path in dotted notation verifying that it is a valid
+// path to a struct field.
+//
+// It returns "path parts" which contain indices to fields to be used by
+// reflect.Value.FieldByString(). Multiple parts are required for slices of
+// structs.
+func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
+	var struc *structInfo
+	var field *fieldInfo
+	var index64 int64
+	var err error
+	parts := make([]pathPart, 0)
+	path := make([]string, 0)
+	keys := strings.Split(p, ".")
+	for i := 0; i < len(keys); i++ {
+		if t.Kind() != reflect.Struct {
+			return nil, invalidPath
+		}
+		if struc = c.get(t); struc == nil {
+			return nil, invalidPath
+		}
+		if field = struc.get(keys[i]); field == nil {
+			return nil, invalidPath
+		}
+		// Valid field. Append index.
+		path = append(path, field.name)
+		if field.ss {
+			// Parse a special case: slices of structs.
+			// i+1 must be the slice index.
+			//
+			// Now that struct can implements TextUnmarshaler interface,
+			// we don't need to force the struct's fields to appear in the path.
+			// So checking i+2 is not necessary anymore.
+			i++
+			if i+1 > len(keys) {
+				return nil, invalidPath
+			}
+			if index64, err = strconv.ParseInt(keys[i], 10, 0); err != nil {
+				return nil, invalidPath
+			}
+			parts = append(parts, pathPart{
+				path:  path,
+				field: field,
+				index: int(index64),
+			})
+			path = make([]string, 0)
+
+			// Get the next struct type, dropping ptrs.
+			if field.typ.Kind() == reflect.Ptr {
+				t = field.typ.Elem()
+			} else {
+				t = field.typ
+			}
+			if t.Kind() == reflect.Slice {
+				t = t.Elem()
+				if t.Kind() == reflect.Ptr {
+					t = t.Elem()
+				}
+			}
+		} else if field.typ.Kind() == reflect.Ptr {
+			t = field.typ.Elem()
+		} else {
+			t = field.typ
+		}
+	}
+	// Add the remaining.
+	parts = append(parts, pathPart{
+		path:  path,
+		field: field,
+		index: -1,
+	})
+	return parts, nil
+}
+
+// get returns a cached structInfo, creating it if necessary.
+func (c *cache) get(t reflect.Type) *structInfo {
+	c.l.RLock()
+	info := c.m[t]
+	c.l.RUnlock()
+	if info == nil {
+		info = c.create(t, nil)
+		c.l.Lock()
+		c.m[t] = info
+		c.l.Unlock()
+	}
+	return info
+}
+
+// create creates a structInfo with meta-data about a struct.
+func (c *cache) create(t reflect.Type, info *structInfo) *structInfo {
+	if info == nil {
+		info = &structInfo{fields: []*fieldInfo{}}
+	}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.Anonymous {
+			ft := field.Type
+			if ft.Kind() == reflect.Ptr {
+				ft = ft.Elem()
+			}
+			if ft.Kind() == reflect.Struct {
+				c.create(ft, info)
+			}
+		}
+		c.createField(field, info)
+	}
+	return info
+}
+
+// createField creates a fieldInfo for the given field.
+func (c *cache) createField(field reflect.StructField, info *structInfo) {
+	alias, options := fieldAlias(field, c.tag)
+	if alias == "-" {
+		// Ignore this field.
+		return
+	}
+	// Check if the type is supported and don't cache it if not.
+	// First let's get the basic type.
+	isSlice, isStruct := false, false
+	ft := field.Type
+	if ft.Kind() == reflect.Ptr {
+		ft = ft.Elem()
+	}
+	if isSlice = ft.Kind() == reflect.Slice; isSlice {
+		ft = ft.Elem()
+		if ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+	}
+	if ft.Kind() == reflect.Array {
+		ft = ft.Elem()
+		if ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+	}
+	if isStruct = ft.Kind() == reflect.Struct; !isStruct {
+		if conv := c.conv[ft.Kind()]; conv == nil {
+			// Type is not supported.
+			return
+		}
+	}
+
+	info.fields = append(info.fields, &fieldInfo{
+		typ:      field.Type,
+		name:     field.Name,
+		ss:       isSlice && isStruct,
+		alias:    alias,
+		required: options.Contains("required"),
+	})
+}
+
+// converter returns the converter for a type.
+func (c *cache) converter(t reflect.Type) Converter {
+	conv := c.regconv[t]
+	if conv == nil {
+		conv = c.conv[t.Kind()]
+	}
+	return conv
+}
+
+// ----------------------------------------------------------------------------
+
+type structInfo struct {
+	fields []*fieldInfo
+}
+
+func (i *structInfo) get(alias string) *fieldInfo {
+	for _, field := range i.fields {
+		if strings.EqualFold(field.alias, alias) {
+			return field
+		}
+	}
+	return nil
+}
+
+type fieldInfo struct {
+	typ      reflect.Type
+	name     string // field name in the struct.
+	ss       bool   // true if this is a slice of structs.
+	alias    string
+	required bool // tag option
+}
+
+type pathPart struct {
+	field *fieldInfo
+	path  []string // path to the field: walks structs using field names.
+	index int      // struct index in slices of structs.
+}
+
+// ----------------------------------------------------------------------------
+
+// fieldAlias parses a field tag to get a field alias.
+func fieldAlias(field reflect.StructField, tagName string) (alias string, options tagOptions) {
+	if tag := field.Tag.Get(tagName); tag != "" {
+		alias, options = parseTag(tag)
+	}
+	if alias == "" {
+		alias = field.Name
+	}
+	return alias, options
+}
+
+// tagOptions is the string following a comma in a struct field's tag, or
+// the empty string. It does not include the leading comma.
+type tagOptions []string
+
+// parseTag splits a struct field's url tag into its name and comma-separated
+// options.
+func parseTag(tag string) (string, tagOptions) {
+	s := strings.Split(tag, ",")
+	return s[0], s[1:]
+}
+
+// Contains checks whether the tagOptions contains the specified option.
+func (o tagOptions) Contains(option string) bool {
+	for _, s := range o {
+		if s == option {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/gorilla/schema/converter.go
+++ b/vendor/github.com/gorilla/schema/converter.go
@@ -1,0 +1,145 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schema
+
+import (
+	"reflect"
+	"strconv"
+)
+
+type Converter func(string) reflect.Value
+
+var (
+	invalidValue = reflect.Value{}
+	boolType     = reflect.Bool
+	float32Type  = reflect.Float32
+	float64Type  = reflect.Float64
+	intType      = reflect.Int
+	int8Type     = reflect.Int8
+	int16Type    = reflect.Int16
+	int32Type    = reflect.Int32
+	int64Type    = reflect.Int64
+	stringType   = reflect.String
+	uintType     = reflect.Uint
+	uint8Type    = reflect.Uint8
+	uint16Type   = reflect.Uint16
+	uint32Type   = reflect.Uint32
+	uint64Type   = reflect.Uint64
+)
+
+// Default converters for basic types.
+var converters = map[reflect.Kind]Converter{
+	boolType:    convertBool,
+	float32Type: convertFloat32,
+	float64Type: convertFloat64,
+	intType:     convertInt,
+	int8Type:    convertInt8,
+	int16Type:   convertInt16,
+	int32Type:   convertInt32,
+	int64Type:   convertInt64,
+	stringType:  convertString,
+	uintType:    convertUint,
+	uint8Type:   convertUint8,
+	uint16Type:  convertUint16,
+	uint32Type:  convertUint32,
+	uint64Type:  convertUint64,
+}
+
+func convertBool(value string) reflect.Value {
+	if value == "on" {
+		return reflect.ValueOf(true)
+	} else if v, err := strconv.ParseBool(value); err == nil {
+		return reflect.ValueOf(v)
+	}
+	return invalidValue
+}
+
+func convertFloat32(value string) reflect.Value {
+	if v, err := strconv.ParseFloat(value, 32); err == nil {
+		return reflect.ValueOf(float32(v))
+	}
+	return invalidValue
+}
+
+func convertFloat64(value string) reflect.Value {
+	if v, err := strconv.ParseFloat(value, 64); err == nil {
+		return reflect.ValueOf(v)
+	}
+	return invalidValue
+}
+
+func convertInt(value string) reflect.Value {
+	if v, err := strconv.ParseInt(value, 10, 0); err == nil {
+		return reflect.ValueOf(int(v))
+	}
+	return invalidValue
+}
+
+func convertInt8(value string) reflect.Value {
+	if v, err := strconv.ParseInt(value, 10, 8); err == nil {
+		return reflect.ValueOf(int8(v))
+	}
+	return invalidValue
+}
+
+func convertInt16(value string) reflect.Value {
+	if v, err := strconv.ParseInt(value, 10, 16); err == nil {
+		return reflect.ValueOf(int16(v))
+	}
+	return invalidValue
+}
+
+func convertInt32(value string) reflect.Value {
+	if v, err := strconv.ParseInt(value, 10, 32); err == nil {
+		return reflect.ValueOf(int32(v))
+	}
+	return invalidValue
+}
+
+func convertInt64(value string) reflect.Value {
+	if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return reflect.ValueOf(v)
+	}
+	return invalidValue
+}
+
+func convertString(value string) reflect.Value {
+	return reflect.ValueOf(value)
+}
+
+func convertUint(value string) reflect.Value {
+	if v, err := strconv.ParseUint(value, 10, 0); err == nil {
+		return reflect.ValueOf(uint(v))
+	}
+	return invalidValue
+}
+
+func convertUint8(value string) reflect.Value {
+	if v, err := strconv.ParseUint(value, 10, 8); err == nil {
+		return reflect.ValueOf(uint8(v))
+	}
+	return invalidValue
+}
+
+func convertUint16(value string) reflect.Value {
+	if v, err := strconv.ParseUint(value, 10, 16); err == nil {
+		return reflect.ValueOf(uint16(v))
+	}
+	return invalidValue
+}
+
+func convertUint32(value string) reflect.Value {
+	if v, err := strconv.ParseUint(value, 10, 32); err == nil {
+		return reflect.ValueOf(uint32(v))
+	}
+	return invalidValue
+}
+
+func convertUint64(value string) reflect.Value {
+	if v, err := strconv.ParseUint(value, 10, 64); err == nil {
+		return reflect.ValueOf(v)
+	}
+	return invalidValue
+}

--- a/vendor/github.com/gorilla/schema/decoder.go
+++ b/vendor/github.com/gorilla/schema/decoder.go
@@ -1,0 +1,343 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schema
+
+import (
+	"encoding"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// NewDecoder returns a new Decoder.
+func NewDecoder() *Decoder {
+	return &Decoder{cache: newCache()}
+}
+
+// Decoder decodes values from a map[string][]string to a struct.
+type Decoder struct {
+	cache             *cache
+	zeroEmpty         bool
+	ignoreUnknownKeys bool
+}
+
+// SetAliasTag changes the tag used to locate custom field aliases.
+// The default tag is "schema".
+func (d *Decoder) SetAliasTag(tag string) {
+	d.cache.tag = tag
+}
+
+// ZeroEmpty controls the behaviour when the decoder encounters empty values
+// in a map.
+// If z is true and a key in the map has the empty string as a value
+// then the corresponding struct field is set to the zero value.
+// If z is false then empty strings are ignored.
+//
+// The default value is false, that is empty values do not change
+// the value of the struct field.
+func (d *Decoder) ZeroEmpty(z bool) {
+	d.zeroEmpty = z
+}
+
+// IgnoreUnknownKeys controls the behaviour when the decoder encounters unknown
+// keys in the map.
+// If i is true and an unknown field is encountered, it is ignored. This is
+// similar to how unknown keys are handled by encoding/json.
+// If i is false then Decode will return an error. Note that any valid keys
+// will still be decoded in to the target struct.
+//
+// To preserve backwards compatibility, the default value is false.
+func (d *Decoder) IgnoreUnknownKeys(i bool) {
+	d.ignoreUnknownKeys = i
+}
+
+// RegisterConverter registers a converter function for a custom type.
+func (d *Decoder) RegisterConverter(value interface{}, converterFunc Converter) {
+	d.cache.regconv[reflect.TypeOf(value)] = converterFunc
+}
+
+// Decode decodes a map[string][]string to a struct.
+//
+// The first parameter must be a pointer to a struct.
+//
+// The second parameter is a map, typically url.Values from an HTTP request.
+// Keys are "paths" in dotted notation to the struct fields and nested structs.
+//
+// See the package documentation for a full explanation of the mechanics.
+func (d *Decoder) Decode(dst interface{}, src map[string][]string) error {
+	v := reflect.ValueOf(dst)
+	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+		return errors.New("schema: interface must be a pointer to struct")
+	}
+	v = v.Elem()
+	t := v.Type()
+	errors := MultiError{}
+	for path, values := range src {
+		if parts, err := d.cache.parsePath(path, t); err == nil {
+			if err = d.decode(v, path, parts, values); err != nil {
+				errors[path] = err
+			}
+		} else if !d.ignoreUnknownKeys {
+			errors[path] = fmt.Errorf("schema: invalid path %q", path)
+		}
+	}
+	if len(errors) > 0 {
+		return errors
+	}
+	return d.checkRequired(t, src, "")
+}
+
+// checkRequired checks whether requred field empty
+//
+// check type t recursively if t has struct fields, and prefix is same as parsePath: in dotted notation
+//
+// src is the source map for decoding, we use it here to see if those required fields are included in src
+func (d *Decoder) checkRequired(t reflect.Type, src map[string][]string, prefix string) error {
+	struc := d.cache.get(t)
+	if struc == nil {
+		// unexpect, cache.get never return nil
+		return errors.New("cache fail")
+	}
+
+	for _, f := range struc.fields {
+		if f.typ.Kind() == reflect.Struct {
+			err := d.checkRequired(f.typ, src, prefix+f.alias+".")
+			if err != nil {
+				return err
+			}
+		}
+		if f.required {
+			key := f.alias
+			if prefix != "" {
+				key = prefix + key
+			}
+			if isEmpty(f.typ, src[key]) {
+				return fmt.Errorf("%v is empty", key)
+			}
+		}
+	}
+	return nil
+}
+
+// isEmpty returns true if value is empty for specific type
+func isEmpty(t reflect.Type, value []string) bool {
+	if len(value) == 0 {
+		return true
+	}
+	switch t.Kind() {
+	case boolType, float32Type, float64Type, intType, int8Type, int32Type, int64Type, stringType, uint8Type, uint16Type, uint32Type, uint64Type:
+		return len(value[0]) == 0
+	}
+	return false
+}
+
+// decode fills a struct field using a parsed path.
+func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values []string) error {
+	// Get the field walking the struct fields by index.
+	for _, name := range parts[0].path {
+		if v.Type().Kind() == reflect.Ptr {
+			if v.IsNil() {
+				v.Set(reflect.New(v.Type().Elem()))
+			}
+			v = v.Elem()
+		}
+		v = v.FieldByName(name)
+	}
+
+	// Don't even bother for unexported fields.
+	if !v.CanSet() {
+		return nil
+	}
+
+	// Dereference if needed.
+	t := v.Type()
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+		if v.IsNil() {
+			v.Set(reflect.New(t))
+		}
+		v = v.Elem()
+	}
+
+	// Slice of structs. Let's go recursive.
+	if len(parts) > 1 {
+		idx := parts[0].index
+		if v.IsNil() || v.Len() < idx+1 {
+			value := reflect.MakeSlice(t, idx+1, idx+1)
+			if v.Len() < idx+1 {
+				// Resize it.
+				reflect.Copy(value, v)
+			}
+			v.Set(value)
+		}
+		return d.decode(v.Index(idx), path, parts[1:], values)
+	}
+
+	// Get the converter early in case there is one for a slice type.
+	conv := d.cache.converter(t)
+	if conv == nil && t.Kind() == reflect.Slice {
+		var items []reflect.Value
+		elemT := t.Elem()
+		isPtrElem := elemT.Kind() == reflect.Ptr
+		if isPtrElem {
+			elemT = elemT.Elem()
+		}
+
+		// Try to get a converter for the element type.
+		conv := d.cache.converter(elemT)
+		if conv == nil {
+			// As we are not dealing with slice of structs here, we don't need to check if the type
+			// implements TextUnmarshaler interface
+			return fmt.Errorf("schema: converter not found for %v", elemT)
+		}
+
+		for key, value := range values {
+			if value == "" {
+				if d.zeroEmpty {
+					items = append(items, reflect.Zero(elemT))
+				}
+			} else if item := conv(value); item.IsValid() {
+				if isPtrElem {
+					ptr := reflect.New(elemT)
+					ptr.Elem().Set(item)
+					item = ptr
+				}
+				if item.Type() != elemT && !isPtrElem {
+					item = item.Convert(elemT)
+				}
+				items = append(items, item)
+			} else {
+				if strings.Contains(value, ",") {
+					values := strings.Split(value, ",")
+					for _, value := range values {
+						if value == "" {
+							if d.zeroEmpty {
+								items = append(items, reflect.Zero(elemT))
+							}
+						} else if item := conv(value); item.IsValid() {
+							if isPtrElem {
+								ptr := reflect.New(elemT)
+								ptr.Elem().Set(item)
+								item = ptr
+							}
+							if item.Type() != elemT && !isPtrElem {
+								item = item.Convert(elemT)
+							}
+							items = append(items, item)
+						} else {
+							return ConversionError{
+								Key:   path,
+								Type:  elemT,
+								Index: key,
+							}
+						}
+					}
+				} else {
+					return ConversionError{
+						Key:   path,
+						Type:  elemT,
+						Index: key,
+					}
+				}
+			}
+		}
+		value := reflect.Append(reflect.MakeSlice(t, 0, 0), items...)
+		v.Set(value)
+	} else {
+		val := ""
+		// Use the last value provided if any values were provided
+		if len(values) > 0 {
+			val = values[len(values)-1]
+		}
+
+		if val == "" {
+			if d.zeroEmpty {
+				v.Set(reflect.Zero(t))
+			}
+		} else if conv != nil {
+			if value := conv(val); value.IsValid() {
+				v.Set(value.Convert(t))
+			} else {
+				return ConversionError{
+					Key:   path,
+					Type:  t,
+					Index: -1,
+				}
+			}
+		} else {
+			// When there's no registered conversion for the custom type, we will check if the type
+			// implements the TextUnmarshaler interface. As the UnmarshalText function should be applied
+			// to the pointer of the type, we convert the value to pointer.
+			if v.CanAddr() {
+				v = v.Addr()
+			}
+
+			if u, ok := v.Interface().(encoding.TextUnmarshaler); ok {
+				if err := u.UnmarshalText([]byte(val)); err != nil {
+					return ConversionError{
+						Key:   path,
+						Type:  t,
+						Index: -1,
+						Err:   err,
+					}
+				}
+
+			} else {
+				return fmt.Errorf("schema: converter not found for %v", t)
+			}
+		}
+	}
+	return nil
+}
+
+// Errors ---------------------------------------------------------------------
+
+// ConversionError stores information about a failed conversion.
+type ConversionError struct {
+	Key   string       // key from the source map.
+	Type  reflect.Type // expected type of elem
+	Index int          // index for multi-value fields; -1 for single-value fields.
+	Err   error        // low-level error (when it exists)
+}
+
+func (e ConversionError) Error() string {
+	var output string
+
+	if e.Index < 0 {
+		output = fmt.Sprintf("schema: error converting value for %q", e.Key)
+	} else {
+		output = fmt.Sprintf("schema: error converting value for index %d of %q",
+			e.Index, e.Key)
+	}
+
+	if e.Err != nil {
+		output = fmt.Sprintf("%s. Details: %s", output, e.Err)
+	}
+
+	return output
+}
+
+// MultiError stores multiple decoding errors.
+//
+// Borrowed from the App Engine SDK.
+type MultiError map[string]error
+
+func (e MultiError) Error() string {
+	s := ""
+	for _, err := range e {
+		s = err.Error()
+		break
+	}
+	switch len(e) {
+	case 0:
+		return "(0 errors)"
+	case 1:
+		return s
+	case 2:
+		return s + " (and 1 other error)"
+	}
+	return fmt.Sprintf("%s (and %d other errors)", s, len(e)-1)
+}

--- a/vendor/github.com/gorilla/schema/doc.go
+++ b/vendor/github.com/gorilla/schema/doc.go
@@ -1,0 +1,148 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package gorilla/schema fills a struct with form values.
+
+The basic usage is really simple. Given this struct:
+
+	type Person struct {
+		Name  string
+		Phone string
+	}
+
+...we can fill it passing a map to the Decode() function:
+
+	values := map[string][]string{
+		"Name":  {"John"},
+		"Phone": {"999-999-999"},
+	}
+	person := new(Person)
+	decoder := schema.NewDecoder()
+	decoder.Decode(person, values)
+
+This is just a simple example and it doesn't make a lot of sense to create
+the map manually. Typically it will come from a http.Request object and
+will be of type url.Values: http.Request.Form or http.Request.MultipartForm:
+
+	func MyHandler(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseForm()
+
+		if err != nil {
+			// Handle error
+		}
+
+		decoder := schema.NewDecoder()
+		// r.PostForm is a map of our POST form values
+		err := decoder.Decode(person, r.PostForm)
+
+		if err != nil {
+			// Handle error
+		}
+
+		// Do something with person.Name or person.Phone
+	}
+
+Note: it is a good idea to set a Decoder instance as a package global,
+because it caches meta-data about structs, and a instance can be shared safely:
+
+	var decoder = schema.NewDecoder()
+
+To define custom names for fields, use a struct tag "schema". To not populate
+certain fields, use a dash for the name and it will be ignored:
+
+	type Person struct {
+		Name  string `schema:"name"`  // custom name
+		Phone string `schema:"phone"` // custom name
+		Admin bool   `schema:"-"`     // this field is never set
+	}
+
+The supported field types in the destination struct are:
+
+	* bool
+	* float variants (float32, float64)
+	* int variants (int, int8, int16, int32, int64)
+	* string
+	* uint variants (uint, uint8, uint16, uint32, uint64)
+	* struct
+	* a pointer to one of the above types
+	* a slice or a pointer to a slice of one of the above types
+
+Non-supported types are simply ignored, however custom types can be registered
+to be converted.
+
+To fill nested structs, keys must use a dotted notation as the "path" for the
+field. So for example, to fill the struct Person below:
+
+	type Phone struct {
+		Label  string
+		Number string
+	}
+
+	type Person struct {
+		Name  string
+		Phone Phone
+	}
+
+...the source map must have the keys "Name", "Phone.Label" and "Phone.Number".
+This means that an HTML form to fill a Person struct must look like this:
+
+	<form>
+		<input type="text" name="Name">
+		<input type="text" name="Phone.Label">
+		<input type="text" name="Phone.Number">
+	</form>
+
+Single values are filled using the first value for a key from the source map.
+Slices are filled using all values for a key from the source map. So to fill
+a Person with multiple Phone values, like:
+
+	type Person struct {
+		Name   string
+		Phones []Phone
+	}
+
+...an HTML form that accepts three Phone values would look like this:
+
+	<form>
+		<input type="text" name="Name">
+		<input type="text" name="Phones.0.Label">
+		<input type="text" name="Phones.0.Number">
+		<input type="text" name="Phones.1.Label">
+		<input type="text" name="Phones.1.Number">
+		<input type="text" name="Phones.2.Label">
+		<input type="text" name="Phones.2.Number">
+	</form>
+
+Notice that only for slices of structs the slice index is required.
+This is needed for disambiguation: if the nested struct also had a slice
+field, we could not translate multiple values to it if we did not use an
+index for the parent struct.
+
+There's also the possibility to create a custom type that implements the
+TextUnmarshaler interface, and in this case there's no need to registry
+a converter, like:
+
+	type Person struct {
+	  Emails []Email
+	}
+
+	type Email struct {
+	  *mail.Address
+	}
+
+	func (e *Email) UnmarshalText(text []byte) (err error) {
+		e.Address, err = mail.ParseAddress(string(text))
+		return
+	}
+
+...an HTML form that accepts three Email values would look like this:
+
+	<form>
+		<input type="email" name="Emails.0">
+		<input type="email" name="Emails.1">
+		<input type="email" name="Emails.2">
+	</form>
+*/
+package schema

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -264,6 +264,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/emicklei/go-restful",
+			"repository": "https://github.com/emicklei/go-restful",
+			"vcs": "git",
+			"revision": "e9d6cfe95e4be7e9f85e79dab93bebb14a517f20",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/foize/go.fifo",
 			"repository": "https://github.com/foize/go.fifo",
 			"vcs": "git",
@@ -362,6 +370,14 @@
 			"repository": "https://github.com/mattn/go-isatty",
 			"vcs": "git",
 			"revision": "30a891c33c7cde7b02a981314b4228ec99380cca",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/gorilla/schema",
+			"repository": "https://github.com/gorilla/schema",
+			"vcs": "git",
+			"revision": "0164a00ab4cd01d814d8cd5bf63fd9fcea30e23b",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
This is just a quick PoC, will reconsider later.

There are four main Concepts in go-restful:
- Container: the global http.ServeMux, holds a collection of WebServices
- WebService: a collection of Route
- Route: HTTP Method, path and function call
- Filters: dynamically intercepts requests and responses, can be used
as middleware