### PR TITLE
fixed bug

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,7 +124,10 @@ func main() {
 			return err
 		}
 
-		node, _ := NewNode(config, db)
+		node, err := NewNode(config, db)
+		if err != nil {
+			logrus.Fatal("Node initialization failed")
+		}
 		go func() {
 			if err := node.Start(context.Background()); err != nil {
 				logrus.Errorf("strart node got error: %s", err.Error())

--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -67,7 +67,7 @@ func New(config config.SwanConfig, db *bolt.DB) (*Manager, error) {
 	manager.swanContext.Config.IPAM.StorePath = fmt.Sprintf(manager.config.IPAM.StorePath+"ipam.db.%d", config.Raft.RaftId)
 	manager.ipamAdapter, err = ipam.New(manager.swanContext)
 	if err != nil {
-		logrus.Errorf("init ipam adapter failed. Error: ", err.Error())
+		logrus.Errorf("init ipam adapter failed. Error: %s", err.Error())
 		return nil, err
 	}
 


### PR DESCRIPTION
ERRO[2016-12-21 11:43:05] init ipam adapter failed. Error: %!(EXTRA string=timeout) 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x34c6]

goroutine 23 [running]:
panic(0x686ca0, 0xc4200180d0)
	/usr/local/Cellar/go/1.7.4/libexec/src/runtime/panic.go:500 +0x1a1
main.(*Node).Start(0x0, 0x1ca8618, 0xc42007c4d0, 0x1ca8618, 0xc42007c4d0)
	/usr/local/go/src/github.com/Dataman-Cloud/swan/node.go:46 +0x26
main.main.func1.1(0x0)
	/usr/local/go/src/github.com/Dataman-Cloud/swan/main.go:129 +0x6b
created by main.main.func1
	/usr/local/go/src/github.com/Dataman-Cloud/swan/main.go:132 +0x2d5