### PR TITLE
fixed bug: `CurrentTask` is nil when `TaskFromRaft`

### DIFF
--- a/src/manager/apiserver/server.go
+++ b/src/manager/apiserver/server.go
@@ -91,6 +91,7 @@ func (apiServer *ApiServer) Start() error {
 		ln, err := net.Listen("unix", apiServer.sock)
 		if err != nil {
 			logrus.Errorf("can't listen on socket %s:%s", apiServer.sock, err.Error())
+			return
 		}
 		logrus.Printf("start listening on %s", apiServer.sock)
 		srv.Serve(ln)

--- a/src/manager/framework/state/slot.go
+++ b/src/manager/framework/state/slot.go
@@ -157,6 +157,7 @@ func (slot *Slot) DispatchNewTask(version *types.Version) {
 	slot.SetState(SLOT_STATE_PENDING_OFFER)
 
 	slot.App.OfferAllocatorRef.PutSlotBackToPendingQueue(slot)
+	slot.update()
 }
 
 func (slot *Slot) UpdateTask(version *types.Version, isRollingUpdate bool) {


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xe8 pc=0x4dde46]

goroutine 42 [running]:
panic(0x637f20, 0xc4200160d0)
	/usr/local/opt/go/libexec/src/runtime/panic.go:500 +0x1a1
github.com/Dataman-Cloud/swan/src/manager/framework/state.TaskFromRaft(0x0, 0x604f7)
	/usr/local/go/src/github.com/Dataman-Cloud/swan/src/manager/framework/state/convert.go:418 +0x26
github.com/Dataman-Cloud/swan/src/manager/framework/state.SlotFromRaft(0xc42014ef00, 0x2)
	/usr/local/go/src/github.com/Dataman-Cloud/swan/src/manager/framework/state/convert.go:367 +0x33
github.com/Dataman-Cloud/swan/src/manager/framework/state.LoadAppSlots(0xc4202600c0, 0xc42025c390, 0x5, 0xa625f8, 0x0, 0x0)
	/usr/local/go/src/github.com/Dataman-Cloud/swan/src/manager/framework/state/recover.go:73 +0x2ac
github.com/Dataman-Cloud/swan/src/manager/framework/state.LoadAppData(0xc420189200, 0xc42018b2c0, 0xc4201a83c0, 0x1, 0x0, 0x0)
	/usr/local/go/src/github.com/Dataman-Cloud/swan/src/manager/framework/state/recover.go:48 +0x56f
github.com/Dataman-Cloud/swan/src/manager/framework/scheduler.(*Scheduler).Start(0xc42019e480, 0x1aa4030, 0xc420150100, 0x0, 0x0)
	/usr/local/go/src/github.com/Dataman-Cloud/swan/src/manager/framework/scheduler/scheduler.go:77 +0x64
github.com/Dataman-Cloud/swan/src/manager/framework.(*Framework).Start.func2(0xc42025c370, 0xc42025c360, 0xc42017d8a0, 0x1aa4030, 0xc420150100)
	/usr/local/go/src/github.com/Dataman-Cloud/swan/src/manager/framework/framework.go:52 +0x56
created by github.com/Dataman-Cloud/swan/src/manager/framework.(*Framework).Start
	/usr/local/go/src/github.com/Dataman-Cloud/swan/src/manager/framework/framework.go:53 +0x155