### PR TITLE
Update slot's IP when AppMode is fixed

### DIFF
--- a/src/manager/framework/state/app.go
+++ b/src/manager/framework/state/app.go
@@ -370,6 +370,10 @@ func (app *App) checkProposedVersionValid(version *types.Version) error {
 	if version.Instances != app.CurrentVersion.Instances {
 		return fmt.Errorf("instances can not change when update app, current version is %d", app.CurrentVersion.Instances)
 	}
+	// fixed app IP length should be same as current instances
+	if app.IsFixed() && int32(len(version.IP)) != app.CurrentVersion.Instances {
+		return fmt.Errorf("Fixed mode App IP length can not change when update app, current version is %d", app.CurrentVersion.Instances)
+	}
 	return nil
 }
 

--- a/src/manager/framework/state/state_updating.go
+++ b/src/manager/framework/state/state_updating.go
@@ -70,6 +70,9 @@ func (updating *StateUpdating) Step() {
 
 		logrus.Infof("archive current task")
 		updating.CurrentSlot.Archive()
+		if updating.App.IsFixed() {
+			updating.CurrentSlot.Ip = updating.App.ProposedVersion.IP[updating.CurrentSlotIndex]
+		}
 		updating.CurrentSlot.DispatchNewTask(updating.App.ProposedVersion)
 
 	} else if updating.CurrentSlot.StateIs(SLOT_STATE_TASK_RUNNING) &&


### PR DESCRIPTION
Run into a problem that updating IPs of fixed APP is not working.

After some dig, seems the slot's IP did not set while updating, 
hope it is the right place to change, and Not tested. :-)
