### PR TITLE
rm application `mode`

### DIFF
--- a/example/template-fixed.json
+++ b/example/template-fixed.json
@@ -1,5 +1,5 @@
 {
-  "appName": "mysql",
+  "appName": "mysql2",
   "appVersion": "version1",
   "cmd": null,
   "cpus": 0.4,
@@ -8,8 +8,7 @@
   "runAs": "xcm",
   "priority": 100,
   "instances": 1,
-  "constraints": [
-  ],
+  "constraints": "",
   "container": {
     "docker": {
       "image": "mysql",

--- a/example/template-fixed.json
+++ b/example/template-fixed.json
@@ -46,6 +46,5 @@
       "consecutiveFailures": 500
     }
  ,
-  "mode": "fixed",
   "ip": ["192.168.1.210"]
 }

--- a/example/template-replicates-memcached.json
+++ b/example/template-replicates-memcached.json
@@ -13,7 +13,7 @@
   "container": {
     "docker": {
       "image": "memcached",
-      "network": "HOST",
+      "network": "host",
       "forcePullImage": false,
       "privileged": true,
       "parameters": [
@@ -55,6 +55,5 @@
       "portName": "memcached",
       "timeoutSeconds": 4,
       "consecutiveFailures": 500
-    } ,
-  "mode": "replicates"
+    }
 }

--- a/example/template-replicates-nginx.json
+++ b/example/template-replicates-nginx.json
@@ -57,6 +57,4 @@
       "timeoutSeconds": 2,
       "consecutiveFailures": 10
     }
- ,
-  "mode": "replicates"
 }

--- a/example/template-replicates.json
+++ b/example/template-replicates.json
@@ -13,7 +13,7 @@
   "container": {
     "docker": {
       "image": "wordpress",
-      "network": "HOST",
+      "network": "host",
       "forcePullImage": false,
       "privileged": true,
       "parameters": [
@@ -60,6 +60,4 @@
       "timeoutSeconds": 1,
       "consecutiveFailures": 500
     }
- ,
-  "mode": "replicates"
 }

--- a/src/manager/framework/state/app.go
+++ b/src/manager/framework/state/app.go
@@ -88,12 +88,6 @@ func NewApp(version *types.Version,
 		Updated:        time.Now(),
 		UserEventChan:  userEventChan,
 	}
-
-	//if version.Mode == "fixed" {
-	//	app.Mode = APP_MODE_FIXED
-	//} else { // if no mode specified, default should be replicates
-	//	app.Mode = APP_MODE_REPLICATES
-	//}
 	network := strings.ToLower(version.Container.Docker.Network)
 	if network != "host" && network != "bridge" {
 		app.Mode = APP_MODE_FIXED
@@ -379,6 +373,11 @@ func (app *App) Step() {
 
 // make sure proposed version is valid then applied it to field ProposedVersion
 func (app *App) checkProposedVersionValid(version *types.Version) error {
+	if version.Container.Docker.Network != app.CurrentVersion.Container.Docker.Network {
+		return fmt.Errorf("network can not change when update app, current network is %s",
+			app.CurrentVersion.Container.Docker.Network)
+	}
+
 	// runAs can not change
 	if version.RunAs != app.CurrentVersion.RunAs {
 		return fmt.Errorf("runAs can not change when update app, current version is %s", app.CurrentVersion.RunAs)

--- a/src/manager/framework/state/convert.go
+++ b/src/manager/framework/state/convert.go
@@ -47,7 +47,6 @@ func VersionToRaft(version *types.Version, appID string) *rafttypes.Version {
 		Constraints: version.Constraints,
 		Uris:        version.URIs,
 		Ip:          version.IP,
-		Mode:        version.Mode,
 		AppName:     version.AppName,
 		AppID:       appID,
 		AppVersion:  version.AppVersion,
@@ -89,7 +88,6 @@ func VersionFromRaft(raftVersion *rafttypes.Version) *types.Version {
 		Constraints: raftVersion.Constraints,
 		URIs:        raftVersion.Uris,
 		IP:          raftVersion.Ip,
-		Mode:        raftVersion.Mode,
 		AppVersion:  raftVersion.AppVersion,
 	}
 

--- a/src/types/version.go
+++ b/src/types/version.go
@@ -21,7 +21,6 @@ type Version struct {
 	Constraints  string            `json:"constraints,omitempty"`
 	URIs         []string          `json:"uris,omitempty"`
 	IP           []string          `json:"ip,omitempty"`
-	Mode         string            `json:"mode"`
 }
 
 type Container struct {


### PR DESCRIPTION
No need to specify the app mode when creating an app.
swan can automated determine the application mode according the network you provided. If the network is `host` or `bridge`, the `mode` is `replicates`; otherwise the `mode` is `fixed`. you must provided the `ip` list when your application `mode` is `fixed`.