### PR TITLE
fixed #507: update `docker-build` image to `golang:1.8.1-alpine`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GO_LDFLAGS=-X $(PKG)/src/version.version=$(VERSION) -X $(PKG)/src/version.gitCom
 default: build
 
 docker-build:
-	docker run --rm -w /go/src/github.com/Dataman-Cloud/swan -e CGO_ENABLED=0 -e GOOS=linux -e GOARCH=amd64  -v $(shell pwd):/go/src/github.com/Dataman-Cloud/swan golang:1.6.3-alpine sh -c 'go build -ldflags "${GO_LDFLAGS}" -v -o bin/swan main.go'
+	docker run --rm -w /go/src/github.com/Dataman-Cloud/swan -e CGO_ENABLED=0 -e GOOS=linux -e GOARCH=amd64  -v $(shell pwd):/go/src/github.com/Dataman-Cloud/swan golang:1.8.1-alpine sh -c 'go build -ldflags "${GO_LDFLAGS}" -v -o bin/swan main.go'
 
 build: fmt
 	go build -ldflags "${GO_LDFLAGS}" -v -o bin/swan main.go

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/Dataman-Cloud/swan/src/cmd"
+	_ "github.com/Dataman-Cloud/swan/src/debug"
 	"github.com/Dataman-Cloud/swan/src/version"
 )
 


### PR DESCRIPTION
`http.Server` has no method `Close` with golang1.6.x or 1.7.x , update to golang1.8.1.