### PR TITLE
tiny fix

### DIFF
--- a/src/manager/api/events_api.go
+++ b/src/manager/api/events_api.go
@@ -16,15 +16,13 @@ import (
 
 type EventsService struct {
 	Scheduler *scheduler.Scheduler
-	apiserver.ApiRegister
 }
 
-func NewAndInstallEventsService(apiServer *apiserver.ApiServer, eng *scheduler.Scheduler) *EventsService {
+func NewAndInstallEventsService(apiServer *apiserver.ApiServer, eng *scheduler.Scheduler) {
 	statsService := &EventsService{
 		Scheduler: eng,
 	}
 	apiserver.Install(apiServer, statsService)
-	return statsService
 }
 
 func (api *EventsService) Register(container *restful.Container) {

--- a/src/manager/api/framework_api.go
+++ b/src/manager/api/framework_api.go
@@ -6,23 +6,17 @@ import (
 	"github.com/Dataman-Cloud/swan/src/config"
 	"github.com/Dataman-Cloud/swan/src/manager/apiserver"
 	"github.com/Dataman-Cloud/swan/src/manager/apiserver/metrics"
-	"github.com/Dataman-Cloud/swan/src/manager/scheduler"
+	"github.com/Dataman-Cloud/swan/src/manager/connector"
 	"github.com/Dataman-Cloud/swan/src/types"
 
 	"github.com/emicklei/go-restful"
 )
 
 type FrameworkService struct {
-	sched *scheduler.Scheduler
-	apiserver.ApiRegister
 }
 
-func NewAndInstallFrameworkService(apiServer *apiserver.ApiServer, sched *scheduler.Scheduler) *FrameworkService {
-	frameworkService := &FrameworkService{
-		sched: sched,
-	}
-	apiserver.Install(apiServer, frameworkService)
-	return frameworkService
+func NewAndInstallFrameworkService(apiServer *apiserver.ApiServer) {
+	apiserver.Install(apiServer, new(FrameworkService))
 }
 
 func (fs *FrameworkService) Register(container *restful.Container) {
@@ -43,8 +37,8 @@ func (fs *FrameworkService) Register(container *restful.Container) {
 
 func (fs *FrameworkService) Info(req *restful.Request, resp *restful.Response) {
 	info := new(types.FrameworkInfo)
-	if fs.sched.MesosConnector != nil {
-		info.ID = fs.sched.MesosConnector.FrameworkInfo.GetId().GetValue()
+	if c := connector.Instance(); c != nil {
+		info.ID = c.FrameworkInfo.GetId().GetValue()
 	} else {
 		info.ID = ""
 	}

--- a/src/manager/api/health_api.go
+++ b/src/manager/api/health_api.go
@@ -6,22 +6,14 @@ import (
 	"github.com/Dataman-Cloud/swan/src/config"
 	"github.com/Dataman-Cloud/swan/src/manager/apiserver"
 	"github.com/Dataman-Cloud/swan/src/manager/apiserver/metrics"
-	"github.com/Dataman-Cloud/swan/src/manager/scheduler"
 
 	"github.com/emicklei/go-restful"
 )
 
-type HealthyService struct {
-	Scheduler *scheduler.Scheduler
-	apiserver.ApiRegister
-}
+type HealthyService struct{}
 
-func NewAndInstallHealthyService(apiServer *apiserver.ApiServer, eng *scheduler.Scheduler) *HealthyService {
-	healthyService := &HealthyService{
-		Scheduler: eng,
-	}
-	apiserver.Install(apiServer, healthyService)
-	return healthyService
+func NewAndInstallHealthyService(apiServer *apiserver.ApiServer) {
+	apiserver.Install(apiServer, new(HealthyService))
 }
 
 func (api *HealthyService) Register(container *restful.Container) {

--- a/src/manager/api/http_api.go
+++ b/src/manager/api/http_api.go
@@ -26,13 +26,12 @@ type AppService struct {
 	apiServer *apiserver.ApiServer
 }
 
-func NewAndInstallAppService(apiServer *apiserver.ApiServer, eng *scheduler.Scheduler) *AppService {
+func NewAndInstallAppService(apiServer *apiserver.ApiServer, eng *scheduler.Scheduler) {
 	appService := &AppService{
 		Scheduler: eng,
 		apiServer: apiServer,
 	}
 	apiserver.Install(apiServer, appService)
-	return appService
 }
 
 // NOTE(xychu): Every service need to registed to ApiServer need to impl

--- a/src/manager/api/stats_api.go
+++ b/src/manager/api/stats_api.go
@@ -17,15 +17,13 @@ import (
 
 type StatsService struct {
 	Scheduler *scheduler.Scheduler
-	apiserver.ApiRegister
 }
 
-func NewAndInstallStatsService(apiServer *apiserver.ApiServer, eng *scheduler.Scheduler) *StatsService {
+func NewAndInstallStatsService(apiServer *apiserver.ApiServer, eng *scheduler.Scheduler) {
 	statsService := &StatsService{
 		Scheduler: eng,
 	}
 	apiserver.Install(apiServer, statsService)
-	return statsService
 }
 
 func (api *StatsService) Register(container *restful.Container) {

--- a/src/manager/api/version_api.go
+++ b/src/manager/api/version_api.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Dataman-Cloud/swan/src/config"
 	"github.com/Dataman-Cloud/swan/src/manager/apiserver"
 	"github.com/Dataman-Cloud/swan/src/manager/apiserver/metrics"
-	"github.com/Dataman-Cloud/swan/src/manager/scheduler"
 	"github.com/Dataman-Cloud/swan/src/version"
 
 	restful "github.com/emicklei/go-restful"
@@ -15,10 +14,8 @@ import (
 type VersionService struct {
 }
 
-func NewAndInstallVersionService(apiServer *apiserver.ApiServer, eng *scheduler.Scheduler) *VersionService {
-	vs := &VersionService{}
-	apiserver.Install(apiServer, vs)
-	return vs
+func NewAndInstallVersionService(apiServer *apiserver.ApiServer) {
+	apiserver.Install(apiServer, new(VersionService))
 }
 
 func (api *VersionService) Register(container *restful.Container) {

--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -81,9 +81,9 @@ func New(managerConf config.ManagerConfig) (*Manager, error) {
 	api.NewAndInstallAppService(route, sched)
 	api.NewAndInstallStatsService(route, sched)
 	api.NewAndInstallEventsService(route, sched)
-	api.NewAndInstallHealthyService(route, sched)
-	api.NewAndInstallFrameworkService(route, sched)
-	api.NewAndInstallVersionService(route, sched)
+	api.NewAndInstallHealthyService(route)
+	api.NewAndInstallFrameworkService(route)
+	api.NewAndInstallVersionService(route)
 
 	return &Manager{
 		apiServer:          route,


### PR DESCRIPTION
based #502, removed unused `return`
by the way: maybe we should merge `Framework` & `Scheduler`, they're almost the same now.