### PR TITLE
avoid to add one header key twice

### DIFF
--- a/src/manager/api/server/server.go
+++ b/src/manager/api/server/server.go
@@ -203,6 +203,8 @@ func (s *ApiServer) ProxyRequest() restful.FilterFunction {
 		}
 
 		rr, err := http.NewRequest(r.Method, leaderURL.String(), r.Body)
+		rr.RequestURI = r.RequestURI
+		rr.URL.RawQuery = r.URL.RawQuery
 		if err != nil {
 			http.Error(resp, err.Error(), http.StatusInternalServerError)
 			return

--- a/src/manager/api/server/server.go
+++ b/src/manager/api/server/server.go
@@ -237,7 +237,7 @@ func (s *ApiServer) ProxyRequest() restful.FilterFunction {
 func copyHeader(source http.Header, dest *http.Header) {
 	for n, v := range source {
 		for _, vv := range v {
-			dest.Add(n, vv)
+			dest.Set(n, vv)
 		}
 	}
 }


### PR DESCRIPTION
when a http request to a standby node, it will proxy to leader node, some header key will be added twice, such as 'Access-Control-Allow-Origin', that would cause trouble when we do cross domain request. detail refer to http://stackoverflow.com/q/37594403