### PR TITLE
recover umarshal on compose instance data

### DIFF
--- a/src/manager/store/zk_store.go
+++ b/src/manager/store/zk_store.go
@@ -583,6 +583,13 @@ func (zk *ZKStore) unmarshalAtomicOp(data []byte) (*AtomicOp, error) {
 				return nil, err
 			}
 			ao.Payload = &item
+		case ENTITY_INSTANCE:
+			var item Instance
+			err = json.Unmarshal(tmpAo.Payload, &item)
+			if err != nil {
+				return nil, err
+			}
+			ao.Payload = &item
 		}
 	}
 	return &ao, nil


### PR DESCRIPTION
启动恢复时少了编排实例数据的unmarshal