### PR TITLE
fix dead lock on removing abnormal slot

### DIFF
--- a/src/manager/state/slot.go
+++ b/src/manager/state/slot.go
@@ -136,7 +136,7 @@ func NewSlot(app *App, version *types.Version, index int) *Slot {
 func (slot *Slot) KillTask() {
 	slot.StopRestartPolicy()
 
-	if slot.Dispatched() {
+	if slot.Dispatched() || slot.Abnormal() {
 		slot.SetState(SLOT_STATE_PENDING_KILL)
 		slot.CurrentTask.Kill()
 	} else {


### PR DESCRIPTION
对非正常的task缩容引发死锁，后续也无法进行删除操作，PR修复该问题。