### PR TITLE
fix panic on load db state machine

### DIFF
--- a/src/manager/state/convert.go
+++ b/src/manager/state/convert.go
@@ -483,13 +483,21 @@ func OfferAllocatorItemFromDB(item *store.OfferAllocatorItem) (slotID string, of
 }
 
 func StateMachineFromDB(app *App, machine *store.StateMachine) *StateMachine {
-	return &StateMachine{
-		state: StateFromDB(app, machine.State),
+	state := StateFromDB(app, machine.State)
+
+	if state == nil {
+		return &StateMachine{state: NewStateNormal(app)}
 	}
+
+	return &StateMachine{state: state}
 }
 
 func StateFromDB(app *App, state *store.State) State {
-	slot, _ := app.GetSlot(int(state.CurrentSlotIndex))
+	slot, ok := app.GetSlot(int(state.CurrentSlotIndex))
+	if !ok {
+		return nil
+	}
+
 	switch state.Name {
 	case APP_STATE_NORMAL:
 		return &StateNormal{


### PR DESCRIPTION
临时解决：
  - 启动状态恢复如果缺失slot数据，则重置app状态为normal， 避免panic