### PR TITLE
skip restart watcher on normally finished tasks

### DIFF
--- a/src/manager/state/slot.go
+++ b/src/manager/state/slot.go
@@ -94,6 +94,10 @@ type SlotResource struct {
 
 var testAndRestartFunc = func(s *Slot) bool {
 	if s.Abnormal() {
+		if s.StateIs(SLOT_STATE_TASK_FINISHED) {
+			return false // skip if task normally finished
+		}
+
 		logrus.Printf("slot %s abnormal, retry by dispatching a new task ...", s.ID)
 		s.Archive()
 		s.DispatchNewTask(s.Version)


### PR DESCRIPTION
  - 正常退出的task不再重新调度，比如运行一个容器 `sleep 1s`   

#627 