### PR TITLE
bugfix for multi tasks launching for app updating

### DIFF
--- a/src/manager/scheduler/hdl_offer.go
+++ b/src/manager/scheduler/hdl_offer.go
@@ -32,7 +32,7 @@ func OfferHandler(s *Scheduler, ev event.Event) error {
 			if match {
 				// TODO the following code logic complex, need improvement
 				// offerWrapper cpu/mem/disk deduction recorded within the obj itself
-				_, taskInfo := slot.ReserveOfferAndPrepareTaskInfo(offerWrapper)
+				taskInfo := slot.ReserveOfferAndPrepareTaskInfo(offerWrapper)
 				state.OfferAllocatorInstance().SetOfferSlotMap(offer, slot)
 				taskInfos = append(taskInfos, taskInfo)
 			} else {

--- a/src/manager/state/state_cancel_update.go
+++ b/src/manager/state/state_cancel_update.go
@@ -37,7 +37,7 @@ func (cancelUpdate *StateCancelUpdate) OnEnter() {
 	}
 
 	cancelUpdate.CurrentSlot, _ = cancelUpdate.App.GetSlot(cancelUpdate.CurrentSlotIndex)
-	cancelUpdate.CurrentSlot.KillTask()
+	cancelUpdate.CurrentSlot.KillTask(true)
 }
 
 func (cancelUpdate *StateCancelUpdate) OnExit() {
@@ -63,7 +63,7 @@ func (cancelUpdate *StateCancelUpdate) Step() {
 
 		cancelUpdate.CurrentSlotIndex -= 1
 		cancelUpdate.CurrentSlot, _ = cancelUpdate.App.GetSlot(cancelUpdate.CurrentSlotIndex)
-		cancelUpdate.CurrentSlot.KillTask()
+		cancelUpdate.CurrentSlot.KillTask(true)
 
 		// when last slot got killed
 	} else if (cancelUpdate.CurrentSlot.StateIs(SLOT_STATE_REAP) ||

--- a/src/manager/state/state_deleting.go
+++ b/src/manager/state/state_deleting.go
@@ -35,7 +35,7 @@ func (deleting *StateDeleting) OnEnter() {
 
 	deleting.CurrentSlot, _ = deleting.App.GetSlot(deleting.CurrentSlotIndex)
 	if deleting.CurrentSlot != nil {
-		deleting.CurrentSlot.KillTask()
+		deleting.CurrentSlot.KillTask(true)
 	} else {
 		deleting.App.Remove() // remove self from boltdb store
 
@@ -68,7 +68,7 @@ func (deleting *StateDeleting) Step() {
 		deleting.CurrentSlotIndex -= 1
 		deleting.CurrentSlot, _ = deleting.App.GetSlot(deleting.CurrentSlotIndex)
 		if deleting.CurrentSlot != nil {
-			deleting.CurrentSlot.KillTask()
+			deleting.CurrentSlot.KillTask(true)
 		}
 
 		deleting.lock.Unlock()

--- a/src/manager/state/state_scale_down.go
+++ b/src/manager/state/state_scale_down.go
@@ -37,7 +37,7 @@ func (scaleDown *StateScaleDown) OnEnter() {
 
 	scaleDown.CurrentSlot, _ = scaleDown.App.GetSlot(scaleDown.CurrentSlotIndex)
 	if scaleDown.CurrentSlot != nil {
-		scaleDown.CurrentSlot.KillTask()
+		scaleDown.CurrentSlot.KillTask(true)
 	}
 }
 
@@ -60,7 +60,7 @@ func (scaleDown *StateScaleDown) Step() {
 			scaleDown.App.CurrentVersion.IP = scaleDown.App.CurrentVersion.IP[:scaleDown.CurrentSlotIndex]
 		}
 		scaleDown.CurrentSlot, _ = scaleDown.App.GetSlot(scaleDown.CurrentSlotIndex)
-		scaleDown.CurrentSlot.KillTask()
+		scaleDown.CurrentSlot.KillTask(true)
 
 		scaleDown.lock.Unlock()
 	} else {


### PR DESCRIPTION
更新应用时，会发送多个重复的Task Launch任务，导致slot数据被写花了，
Task的实际 节点/IP/端口数据都是错误的，PR修复此问题。

ping @pwzgorilla  @xiaods 