### PR TITLE
cpu & memory profiling for proxy

### DIFF
--- a/janitor/profile.go
+++ b/janitor/profile.go
@@ -1,0 +1,83 @@
+package janitor
+
+import (
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var (
+	fcpu = filepath.Join(os.TempDir(), "swan-cpu.pprof")
+	fmem = filepath.Join(os.TempDir(), "swan-mem.pprof")
+)
+
+func init() {
+	if env := os.Getenv("PROFILE"); env != "" {
+		log.Warnln("running with profile enabled, stop profiling by SIGINT")
+		prof := newProfile()
+		if err := prof.start(); err != nil {
+			log.Fatalf("could not profile: %v", err)
+		}
+	}
+}
+
+type profile struct {
+	fdcpu           *os.File
+	fdmem           *os.File
+	previsouMemRate int
+}
+
+func newProfile() *profile {
+	var (
+		prof = new(profile)
+	)
+
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		<-c
+
+		log.Println("profile: caught interrupt, stopping profiles")
+		prof.stop()
+		os.Exit(0)
+	}()
+
+	return prof
+}
+
+func (p *profile) start() error {
+	fd, err := os.Create(fcpu)
+	if err != nil {
+		return err
+	}
+	p.fdcpu = fd
+
+	fd, err = os.Create(fmem)
+	if err != nil {
+		p.fdcpu.Close()
+		return err
+	}
+	p.fdmem = fd
+
+	pprof.StartCPUProfile(p.fdcpu)
+
+	p.previsouMemRate = runtime.MemProfileRate
+	runtime.MemProfileRate = 4096
+
+	return nil
+}
+
+func (p *profile) stop() {
+	pprof.StopCPUProfile()
+	if p.fdcpu != nil {
+		p.fdcpu.Close()
+	}
+
+	pprof.Lookup("heap").WriteTo(p.fdmem, 0)
+	p.fdmem.Close()
+	runtime.MemProfileRate = p.previsouMemRate
+}

--- a/janitor/proxy/tcp_proxy.go
+++ b/janitor/proxy/tcp_proxy.go
@@ -103,7 +103,7 @@ func (p *TCPProxyServer) lookup(conn net.Conn) (*upstream.BackendCombined, error
 		return nil, err
 	}
 
-	listen := ":" + localPort // TODO
+	listen := ":" + localPort
 
 	selected := upstream.LookupListen(remoteHost, listen)
 	if selected == nil {

--- a/janitor/upstream/upstream.go
+++ b/janitor/upstream/upstream.go
@@ -309,7 +309,11 @@ func Lookup(remoteIP, ups, backend string) *BackendCombined {
 		b *Backend
 	)
 
-	if _, u = getUpstreamByName(ups); u == nil {
+	mgr.RLock()
+	_, u = getUpstreamByName(ups)
+	mgr.RUnlock()
+
+	if u == nil {
 		return nil
 	}
 


### PR DESCRIPTION
proxy启动增加`PROFILE＝1`环境变量，kill -SIGINT 终止。 
输出在  `/tmp/swan-cpu.pprof`  `/tmp/swan-mem.pprof`