### PR TITLE
add underlying communication component `mole` to serving between swan agents & master

### DIFF
--- a/mole/agent.go
+++ b/mole/agent.go
@@ -1,0 +1,289 @@
+package mole
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var (
+	FILE_UUID = "/etc/.mole.uuid"
+
+	errNotConnected = errors.New("not connected to master")
+	errClosed       = errors.New("agent listener closed")
+)
+
+type Agent struct {
+	id      string   // unique agent id
+	master  *url.URL // master url
+	backend *url.URL // backend url, TODO: support multi backends
+	conn    net.Conn // control connection to master
+	api     *agentApi
+
+	mux    sync.RWMutex  // protect flag closed
+	closed bool          // flag on pool closed
+	pool   chan net.Conn // worker connection pool
+}
+
+func NewAgent(cfg *Config) *Agent {
+	id, err := getAgentID()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	a := &Agent{
+		id:      id,
+		master:  cfg.master,
+		backend: cfg.backend,
+		pool:    make(chan net.Conn, 1024),
+	}
+	a.api = newAgentApi(a.serveProxy)
+	return a
+}
+
+func getAgentID() (string, error) {
+	_, err := os.Stat(FILE_UUID)
+	if os.IsNotExist(err) {
+		uuid := randNumber(16)
+		err = ioutil.WriteFile(FILE_UUID, []byte(uuid), os.FileMode(0400))
+		return string(uuid), err
+	}
+
+	bs, err := ioutil.ReadFile(FILE_UUID)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes.TrimSpace(bs)), nil
+}
+
+func (a *Agent) Join() error {
+	conn, err := net.DialTimeout("tcp", a.master.Host, time.Second*10)
+	if err != nil {
+		return fmt.Errorf("agent Join error: %v", err)
+	}
+
+	// Disable IO Read TimeOut
+	conn.SetReadDeadline(time.Time{})
+	// Setting TCP KeepAlive on the socket connection will prohibit
+	// ECONNTIMEOUT unless the socket connection truly is broken
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetKeepAlive(true)
+		tcpConn.SetKeepAlivePeriod(30 * time.Second)
+	}
+	a.conn = conn
+
+	// send join cmd
+	command := newCmd(cmdJoin, a.id, "")
+	_, err = conn.Write(command)
+
+	return err
+}
+
+func (a *Agent) Serve() error {
+	if a.conn == nil {
+		return errNotConnected
+	}
+	defer a.conn.Close()
+
+	var (
+		errChProt = make(chan error)
+		errChHTTP = make(chan error)
+	)
+	go func() {
+		errChProt <- a.ServeProtocol() // serve cluster protocol
+	}()
+	go func() {
+		errChHTTP <- a.ServeApis() // serve http api
+	}()
+
+	select {
+	case err := <-errChProt:
+		return fmt.Errorf("protocol serving error: %v", err)
+	case err := <-errChHTTP:
+		return fmt.Errorf("httpApi serving error: %v", err)
+	}
+
+	return errors.New("never be here")
+}
+
+func (a *Agent) ServeProtocol() error {
+	// protocol decoder
+	dec := NewDecoder(a.conn)
+
+	for {
+		cmd, err := dec.Decode()
+		if err != nil { // control conn closed, exit Serve() to trigger agent ReJoin
+			return fmt.Errorf("agent decode protocol error: %v", err)
+		}
+		if err := cmd.valid(); err != nil {
+			log.Errorf("agent received invalid command: %v", err)
+			continue
+		}
+
+		// handle master command
+		switch cmd.Cmd {
+
+		case cmdNewWorker: // launch a new tcp connection as the worker connection
+			connWorker, err := net.DialTimeout("tcp", a.master.Host, time.Second*10)
+			if err != nil {
+				log.Errorf("agent dial master error: %v", err)
+				continue
+			}
+			command := newCmd(cmdNewWorker, a.id, cmd.WorkerID)
+			_, err = connWorker.Write(command)
+			if err != nil {
+				log.Errorf("agent notify back worker id error: %v", err)
+				continue
+			}
+
+			// put the worker conn to agent connection pools
+			go a.HandleWorkerConn(connWorker)
+
+		case cmdPing:
+			pong := newCmd(cmdPing, a.id, "")
+			if _, err := a.conn.Write(pong); err != nil {
+				log.Errorf("agent heart pong error: %v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ServeApis serve agent-local http or backend http services
+func (a *Agent) ServeApis() error {
+	a.api.SetupRoutes()
+	server := &http.Server{
+		Handler: a.api,
+	}
+	return server.Serve(a)
+}
+
+func (a *Agent) serveProxy(w http.ResponseWriter, r *http.Request) {
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		w.WriteHeader(500)
+		return
+	}
+
+	connMaster, _, err := hijacker.Hijack()
+	if err != nil {
+		w.WriteHeader(500)
+		return
+	}
+	defer connMaster.Close()
+
+	connBackend, err := a.dialBackend()
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	defer connBackend.Close()
+
+	go func() {
+		r.Write(connBackend)
+	}()
+
+	io.Copy(connMaster, connBackend)
+}
+
+func (a *Agent) dialBackend() (net.Conn, error) {
+	switch a.backend.Scheme {
+	case "unix":
+		return net.Dial(a.backend.Scheme, a.backend.Path)
+	case "tcp", "http", "https":
+		return net.Dial("tcp", a.backend.Host)
+	}
+	return nil, errors.New("not supported backend scheme")
+}
+
+// put the worker connection to the pool
+func (a *Agent) HandleWorkerConn(conn net.Conn) error {
+	a.mux.RLock()
+	defer a.mux.RUnlock()
+	if a.closed {
+		return errClosed
+	}
+	a.pool <- conn
+	return nil
+}
+
+// implement net.Listener interface (process the cached worker connection in the pool)
+func (a *Agent) Accept() (net.Conn, error) {
+	conn, ok := <-a.pool
+	if !ok {
+		return nil, errClosed
+	}
+	return conn, nil
+}
+
+func (a *Agent) Close() error {
+	a.mux.Lock()
+	a.closed = true
+	close(a.pool)
+	a.mux.Unlock()
+	return nil
+}
+
+func (a *Agent) Addr() net.Addr {
+	return a.conn.LocalAddr()
+}
+
+//
+// agentApi is a simple http mutex router
+type agentApi struct {
+	m               map[string]map[string]http.HandlerFunc // method -> path -> handleFunc
+	notFoundHandler http.HandlerFunc
+}
+
+func newAgentApi(notFoundHandler http.HandlerFunc) *agentApi {
+	return &agentApi{
+		m:               make(map[string]map[string]http.HandlerFunc),
+		notFoundHandler: notFoundHandler,
+	}
+}
+
+func (api *agentApi) SetupRoutes() {
+	api.m = map[string]map[string]http.HandlerFunc{
+		"GET": map[string]http.HandlerFunc{
+			"/hello": api.hello,
+		},
+	}
+}
+
+// implement http.Handler interface
+func (api *agentApi) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var (
+		method = r.Method
+		path   = r.URL.Path
+	)
+
+	if m, ok := api.m[method]; ok {
+		if h, ok := m[path]; ok {
+			h(w, r)
+			return
+		}
+	}
+
+	if h := api.notFoundHandler; h != nil {
+		h(w, r)
+		return
+	}
+
+	http.Error(w, "page not found", 404)
+}
+
+func (api *agentApi) hello(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(200)
+	w.Write([]byte("hello world"))
+}

--- a/mole/config.go
+++ b/mole/config.go
@@ -1,0 +1,61 @@
+package mole
+
+import (
+	"errors"
+	"net/url"
+	"os"
+)
+
+var (
+	roleMaster role = "master"
+	roleAgent  role = "agent"
+)
+
+type role string
+
+type Config struct {
+	role    role     // both
+	listen  string   // master only
+	master  *url.URL // agent only
+	backend *url.URL // agent only
+}
+
+func (c *Config) valid() error {
+	switch c.role {
+
+	case roleAgent:
+		if c.master == nil {
+			return errors.New("malform master endpoint")
+		}
+		if c.backend == nil {
+			return errors.New("malform backend endpoint")
+		}
+
+	case roleMaster:
+		if c.listen == "" {
+			return errors.New("malform listen address")
+		}
+
+	default:
+		return errors.New("role must be agent or master")
+	}
+
+	return nil
+}
+
+func ConfigFromEnv() (*Config, error) {
+	cfg := &Config{
+		role:   role(os.Getenv("MOLE_ROLE")),
+		listen: os.Getenv("MOLE_LISTEN"),
+	}
+	if burl, err := url.Parse(os.Getenv("MOLE_BACKEND_ENDPOINT")); err == nil {
+		cfg.backend = burl
+	}
+	if murl, err := url.Parse(os.Getenv("MOLE_MASTER_ENDPOINT")); err == nil {
+		cfg.master = murl
+	}
+	if err := cfg.valid(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/mole/master.go
+++ b/mole/master.go
@@ -1,0 +1,193 @@
+package mole
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+type Master struct {
+	sync.RWMutex                          // protect agents map
+	agents       map[string]*ClusterAgent // agents held all of joined agents
+	listen       string                   // listen address
+	authToken    string                   // TODO auth token
+	heartbeat    time.Duration            // TODO heartbeat interval to ping agents
+}
+
+func NewMaster(cfg *Config) *Master {
+	return &Master{
+		listen:    cfg.listen,
+		authToken: "xxx",
+		heartbeat: time.Second * 60,
+		agents:    make(map[string]*ClusterAgent),
+	}
+}
+
+func (m *Master) Serve() error {
+	l, err := net.Listen("tcp", m.listen)
+	if err != nil {
+		return err
+	}
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			log.Errorln("master Accept error: %v", err)
+			return err
+		}
+
+		go m.handle(conn)
+	}
+
+	return nil
+}
+
+func (m *Master) handle(conn net.Conn) {
+	cmd, err := NewDecoder(conn).Decode()
+	if err != nil {
+		log.Errorf("master decode protocol error: %v", err)
+		return
+	}
+
+	if err := cmd.valid(); err != nil {
+		log.Errorf("master received invalid command: %v", err)
+		return
+	}
+
+	switch cmd.Cmd {
+
+	case cmdJoin:
+		log.Println("agent joined", cmd.AgentID)
+		m.AddAgent(cmd.AgentID, conn) // this is the persistent control connection
+
+	case cmdNewWorker:
+		log.Debugln("agent new worker connection", cmd.WorkerID)
+		pub.Publish(&clusterWorker{
+			agentID:       cmd.AgentID,
+			workerID:      cmd.WorkerID,
+			conn:          conn, // this is the worker connection
+			establishedAt: time.Now(),
+		})
+		m.FreshAgent(cmd.AgentID)
+
+	case cmdLeave: // FIXME better within controll conn instead of here
+		log.Println("agent leaved", cmd.AgentID)
+		m.CloseAgent(cmd.AgentID)
+
+	case cmdPing: // FIXME better within control conn instead of here
+		log.Println("agent heartbeat", cmd.AgentID)
+		m.FreshAgent(cmd.AgentID)
+
+	}
+}
+
+func (m *Master) AddAgent(id string, conn net.Conn) {
+	m.Lock()
+	defer m.Unlock()
+	// if we already have agent connection with the same id
+	// close the previous staled connection and use the new one
+	if agent, ok := m.agents[id]; ok {
+		agent.conn.Close()
+	}
+
+	ca := &ClusterAgent{
+		id:         id,
+		conn:       conn,
+		joinAt:     time.Now(),
+		lastActive: time.Now(),
+	}
+
+	m.agents[id] = ca
+}
+
+func (m *Master) CloseAgent(id string) {
+	m.Lock()
+	defer m.Unlock()
+	if agent, ok := m.agents[id]; ok {
+		agent.conn.Close()
+		delete(m.agents, id)
+	}
+}
+
+func (m *Master) FreshAgent(id string) {
+	m.Lock()
+	defer m.Unlock()
+	if agent, ok := m.agents[id]; ok {
+		agent.lastActive = time.Now()
+	}
+}
+
+// the caller should check the returned ClusterAgent is not nil
+// otherwise the agent hasn't connected to the cluster
+func (m *Master) Agent(id string) *ClusterAgent {
+	m.RLock()
+	defer m.RUnlock()
+	return m.agents[id]
+}
+
+func (m *Master) Agents() map[string]*ClusterAgent {
+	m.RLock()
+	defer m.RUnlock()
+	return m.agents
+}
+
+//
+// ClusterAgent is a runtime agent object within master lifttime
+type ClusterAgent struct {
+	id         string   // agent id
+	conn       net.Conn // persistent control connection
+	joinAt     time.Time
+	lastActive time.Time
+}
+
+// Dial specifies the dial function for creating unencrypted TCP connections within the http.Client
+func (ca *ClusterAgent) Dial(network, addr string) (net.Conn, error) {
+	wid := randNumber(10)
+
+	// notify the agent to create a new worker connection
+	command := newCmd(cmdNewWorker, ca.id, wid)
+	_, err := ca.conn.Write(command)
+	if err != nil {
+		return nil, err
+	}
+
+	// subcribe waitting for the worker id connection
+	sub := pub.Subcribe(func(v interface{}) bool {
+		if vv, ok := v.(*clusterWorker); ok {
+			return vv.workerID == wid && vv.agentID == ca.id
+		}
+		return false
+	})
+	defer pub.Evict(sub) // evict the subcriber before exit
+
+	select {
+	case cw := <-sub:
+		return cw.(*clusterWorker).conn, nil
+	case <-time.After(time.Second * 10):
+		return nil, errors.New("agent Dial(): new worker conn timeout")
+	}
+
+	return nil, errors.New("never be here")
+}
+
+// Client obtain a http client for an agent with customized dialer
+func (ca *ClusterAgent) Client() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Dial: ca.Dial,
+		},
+	}
+}
+
+//
+// clusterWorker is a worker connection
+type clusterWorker struct {
+	agentID       string
+	workerID      string
+	conn          net.Conn
+	establishedAt time.Time
+}

--- a/mole/protocol.go
+++ b/mole/protocol.go
@@ -1,0 +1,152 @@
+package mole
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/gob"
+	"errors"
+	"io"
+)
+
+var (
+	HEADER = []byte("MOLE")
+)
+
+// TODO replace this struct by fixed-size [32]byte
+// so we don't need to use gob to encode/decode the command
+type command struct {
+	Cmd      string // cmdJoin, cmdLeave, cmdNewWorker, cmdPing
+	AgentID  string // require on cmdJoin / cmdLeave / cmdPing
+	WorkerID string // require on cmdNewWorker
+}
+
+var (
+	cmdJoin      = "join"  // agent -> master
+	cmdLeave     = "leave" // agent ->  master
+	cmdPing      = "ping"  // master -> agent
+	cmdNewWorker = "new"   // master -> agent (with new workerID), agent -> master (notify back with the same workerID that conn established)
+)
+
+func (cmd *command) valid() error {
+	switch cmd.Cmd {
+	case cmdJoin, cmdLeave, cmdPing:
+		if cmd.AgentID == "" {
+			return errors.New("protocol: agent id required")
+		}
+	case cmdNewWorker:
+		if cmd.WorkerID == "" {
+			return errors.New("protocol: worker id required")
+		}
+	default:
+		return errors.New("protocol: unknown command")
+	}
+	return nil
+}
+
+func Encode(msg []byte) []byte {
+	ret := make([]byte, 0)
+
+	ret = append(ret, HEADER...) // write header, 4 bytes
+
+	lenBytes := int2bytes(len(msg))
+	ret = append(ret, lenBytes...) // write length of msg body, 4 bytes
+
+	buf := bytes.NewBuffer(nil)
+	binary.Write(buf, binary.BigEndian, msg)
+	ret = append(ret, buf.Bytes()...) // write msg body
+
+	return ret
+}
+
+type Decoder struct {
+	r     io.Reader // read from
+	store []byte    // store the read out bytes
+}
+
+// NewDecoder returns a new protocol decoder that reads from r.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{
+		r:     r,
+		store: make([]byte, 0),
+	}
+}
+
+func (d *Decoder) Buffered() []byte {
+	return d.store
+}
+
+// Decode reads the next protocol-encoded command from reader
+// Note that Decode() is not concurrency safe.
+func (d *Decoder) Decode() (*command, error) {
+	var (
+		headerN = len(HEADER) + 4    // header + length
+		buf     = make([]byte, 1024) // each piece read out
+		n       int
+		err     error
+	)
+
+	// if previous buffered data length over than one header+length
+	// consume them firstly
+	if len(d.Buffered()) >= headerN {
+		goto READ_HEADER
+	}
+
+READ_MORE:
+	// read one piece of data
+	n, err = d.r.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// accumulated append to p.store
+	d.store = append(d.store, buf[:n]...)
+
+	// read more if short than header
+	if len(d.Buffered()) < headerN {
+		goto READ_MORE
+	}
+
+READ_HEADER:
+	// scan the read out buffered data...
+	// read the header and lenghtN firstly
+	var (
+		hl      = d.store[:headerN] // header and length bytes
+		header  = hl[:len(HEADER)]  // header bytes
+		length  = hl[len(HEADER):]  // length bytes
+		lengthN = bytes2int(length) // length int
+	)
+
+	// ensure protocol HEADER
+	if string(header) != "MOLE" {
+		// slice down the consumed abnormal data in d.store
+		d.store = d.store[headerN:]
+		return nil, errors.New("NOT MOLE PROTOCOL")
+	}
+
+	// if readout data not contains a full body, continue read
+	if len(d.Buffered()) < headerN+lengthN {
+		goto READ_MORE
+	}
+
+	// read the body out
+	body := d.store[headerN : headerN+lengthN]
+
+	// slice down the consumed data in d.store
+	d.store = d.store[headerN+lengthN:]
+
+	var (
+		cmd    *command
+		buffer = bytes.NewBuffer(body)
+	)
+	if err := gob.NewDecoder(buffer).Decode(&cmd); err != nil {
+		return nil, err
+	}
+
+	return cmd, nil
+}
+
+func newCmd(cmd, aid, wid string) []byte {
+	buf := bytes.NewBuffer(nil)
+	gob.NewEncoder(buf).Encode(command{cmd, aid, wid})
+	return Encode(buf.Bytes())
+}

--- a/mole/pubsub.go
+++ b/mole/pubsub.go
@@ -1,0 +1,93 @@
+package mole
+
+import (
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var (
+	pub *publisher // global publisher
+)
+
+func init() {
+	pub = newPublisher(time.Second*5, 1024)
+}
+
+type publisher struct {
+	mux sync.RWMutex            // protect m
+	m   map[subcriber]topicFunc // hold all of subcribers
+
+	timeout   time.Duration // send topic timeout
+	bufferLen int           // buffer length of each subcriber channel
+}
+type subcriber chan interface{}
+type topicFunc func(v interface{}) bool
+
+func newPublisher(timeout time.Duration, bufferLen int) *publisher {
+	return &publisher{
+		m:         make(map[subcriber]topicFunc),
+		timeout:   timeout,
+		bufferLen: bufferLen,
+	}
+}
+
+// SubcribeAll adds a new subscriber that receive all messages.
+func (p *publisher) SubcribeAll() subcriber {
+	return p.Subcribe(nil)
+}
+
+// Subcribe adds a new subscriber that filters messages sent by a topic.
+func (p *publisher) Subcribe(tf topicFunc) subcriber {
+	ch := make(subcriber, p.bufferLen)
+	p.mux.Lock()
+	p.m[ch] = tf
+	p.mux.Unlock()
+	return ch
+}
+
+// Evict removes the specified subscriber from receiving any more messages.
+func (p *publisher) Evict(sub subcriber) {
+	p.mux.Lock()
+	delete(p.m, sub)
+	close(sub)
+	p.mux.Unlock()
+}
+
+func (p *publisher) Publish(v interface{}) {
+	p.mux.RLock()
+	defer p.mux.RUnlock()
+
+	var wg sync.WaitGroup
+	wg.Add(len(p.m))
+	// broadcasting with concurrency
+	for sub, tf := range p.m {
+		go func(sub subcriber, v interface{}, tf topicFunc) {
+			defer wg.Done()
+			p.send(sub, v, tf)
+		}(sub, v, tf)
+	}
+	wg.Wait()
+}
+
+func (p *publisher) send(sub subcriber, v interface{}, tf topicFunc) {
+	// if a subcriber setup topic filter func and not matched by the topic filter
+	// skip send message to this subcriber
+	if tf != nil && !tf(v) {
+		return
+	}
+
+	// send with timeout
+	if p.timeout > 0 {
+		select {
+		case sub <- v:
+		case <-time.After(p.timeout):
+			log.Println("send to subcriber timeout after", p.timeout.String())
+		}
+		return
+	}
+
+	// directely send
+	sub <- v
+}

--- a/mole/utils.go
+++ b/mole/utils.go
@@ -1,0 +1,31 @@
+package mole
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+)
+
+func randNumber(length int) string {
+	key := make([]byte, length)
+	rand.Read(key)
+	for i := range key {
+		key[i] = key[i]%10 + '0'
+	}
+	return string(key)
+}
+
+// utils to convert int between bytes
+func int2bytes(n int) []byte { // 4 bytes
+	x := int32(n)
+	buf := bytes.NewBuffer(nil)
+	binary.Write(buf, binary.BigEndian, x)
+	return buf.Bytes()
+}
+
+func bytes2int(bs []byte) int {
+	var x int32
+	buf := bytes.NewBuffer(bs)
+	binary.Read(buf, binary.BigEndian, &x)
+	return int(x)
+}


### PR DESCRIPTION
新增集群间通讯的基础组件：
 - 可在master上管控所有的节点资源和下发指令。
 - 接管节点的docker API，节点上docker不再需要对外开放端口。
 - 控制协议：二进制（长连接）， 业务协议：标准HTTP 

See More: https://github.com/bbklab/demos/tree/master/mole