### PR TITLE
sync calling to update agents' proxy & dns records

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -27,7 +27,7 @@ type Agent struct {
 func New(cfg config.AgentConfig) *Agent {
 	agent := &Agent{
 		config:   cfg,
-		resolver: nameserver.NewResolver(&cfg.DNS),
+		resolver: nameserver.NewResolver(&cfg.DNS, cfg.Janitor.AdvertiseIP),
 		janitor:  janitor.NewJanitorServer(&cfg.Janitor),
 	}
 	return agent

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,27 +1,20 @@
 package agent
 
 import (
-	"bufio"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 
 	"github.com/Dataman-Cloud/swan/agent/janitor"
-	"github.com/Dataman-Cloud/swan/agent/janitor/upstream"
 	"github.com/Dataman-Cloud/swan/agent/nameserver"
 	"github.com/Dataman-Cloud/swan/config"
 	"github.com/Dataman-Cloud/swan/mole"
-	"github.com/Dataman-Cloud/swan/types"
-	"github.com/Dataman-Cloud/swan/utils"
 )
 
 type Agent struct {
@@ -29,7 +22,6 @@ type Agent struct {
 	resolver    *nameserver.Resolver
 	janitor     *janitor.JanitorServer
 	clusterNode *mole.Agent
-	eventCh     chan []byte
 }
 
 func New(cfg config.AgentConfig) *Agent {
@@ -37,7 +29,6 @@ func New(cfg config.AgentConfig) *Agent {
 		config:   cfg,
 		resolver: nameserver.NewResolver(&cfg.DNS),
 		janitor:  janitor.NewJanitorServer(&cfg.Janitor),
-		eventCh:  make(chan []byte, 1024),
 	}
 	return agent
 }
@@ -169,10 +160,6 @@ func (agent *Agent) dialBackend() (net.Conn, error) {
 	return net.Dial("unix", "/var/run/docker.sock")
 }
 
-//
-// clean up followings laster
-//
-
 func (agent *Agent) detectManagerAddr() (string, error) {
 	for _, addr := range agent.config.JoinAddrs {
 		resp, err := http.Get("http://" + addr + "/ping")
@@ -187,173 +174,4 @@ func (agent *Agent) detectManagerAddr() (string, error) {
 	}
 
 	return "", errors.New("all of swan manager unavailable")
-}
-
-func (agent *Agent) watchEvents() {
-	var (
-		delayMin = time.Millisecond * 500 // min retry delay 0.5s
-		delayMax = time.Second * 60       // max retry delay 60s
-		delay    = delayMin               // retry delay
-	)
-
-	for {
-		managerAddr, err := agent.detectManagerAddr()
-		if err != nil {
-			log.Errorln("agent Join error:", err)
-			delay *= 2
-			if delay > delayMax {
-				delay = delayMax // reset to max
-			}
-			log.Printf("agent Rejoin in %s ...", delay)
-			time.Sleep(delay)
-			continue
-		}
-
-		log.Printf("agent Join to manager %s succeed, ready for events ...", managerAddr)
-		delay = delayMin // reset to min
-
-		err = agent.watchManagerEvents(managerAddr)
-		if err != nil {
-			log.Errorf("agent watch on manager events error: %v, retry ...", err)
-			time.Sleep(time.Second)
-		}
-	}
-}
-
-func (agent *Agent) dispatchEvents() {
-	// send local proxy dns record to dns
-	var (
-		proxyIP = agent.config.Janitor.AdvertiseIP
-		ev      = nameserver.BuildRecordEvent("add", "local_proxy", "PROXY", proxyIP, "80", 0, true)
-	)
-	agent.resolver.EmitChange(ev)
-
-	for evBody := range agent.eventCh {
-		log.Printf("agent caught sse task event: %s", string(evBody))
-
-		var taskEv types.TaskEvent
-		if err := json.Unmarshal(evBody, &taskEv); err != nil {
-			log.Errorf("agent unmarshal task event error: %v", err)
-			continue
-		}
-
-		if taskEv.GatewayEnabled {
-			ev := genJanitorBackendEvent(&taskEv)
-			if ev != nil {
-				agent.janitor.EmitEvent(ev)
-			}
-		}
-
-		if taskEv.Type == types.EventTypeTaskHealthy || taskEv.Type == types.EventTypeTaskUnhealthy {
-			ev := genDNSRecordEvent(&taskEv)
-			if ev != nil {
-				agent.resolver.EmitChange(ev)
-			}
-		}
-	}
-}
-
-func (agent *Agent) watchManagerEvents(managerAddr string) error {
-	eventsDoesMatter := []string{
-		types.EventTypeTaskUnhealthy,
-		types.EventTypeTaskHealthy,
-		types.EventTypeTaskWeightChange,
-	}
-
-	eventsPath := fmt.Sprintf("http://%s/v1/events?catchUp=true", managerAddr)
-	resp, err := http.Get(eventsPath)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	var (
-		ssePrefixData  = "data:"
-		ssePrefixEvent = "event:"
-		prefixDataLen  = len(ssePrefixData)
-		prefixEventLen = len(ssePrefixEvent)
-		reader         = bufio.NewReader(resp.Body)
-	)
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			return err
-		}
-
-		// skip blank line
-		if line == "" {
-			continue
-		}
-
-		if strings.HasPrefix(line, ssePrefixEvent) {
-			eventType := strings.TrimSpace(line[prefixEventLen:])
-			if !utils.SliceContains(eventsDoesMatter, eventType) {
-				continue
-			}
-
-			// read next line of stream
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				return err
-			}
-			// if line is not data section
-			if !strings.HasPrefix(line, ssePrefixData) {
-				continue
-			}
-
-			agent.eventCh <- []byte(line[prefixDataLen:])
-		}
-	}
-}
-
-func genDNSRecordEvent(taskEv *types.TaskEvent) *nameserver.RecordEvent {
-	var (
-		act    string
-		aid    = taskEv.AppID
-		tid    = taskEv.TaskID
-		ip     = taskEv.IP
-		port   = fmt.Sprintf("%d", taskEv.Port)
-		weight = taskEv.Weight
-	)
-	switch taskEv.Type {
-	case types.EventTypeTaskHealthy:
-		act = "add"
-	case types.EventTypeTaskUnhealthy:
-		act = "del"
-	default:
-		return nil
-	}
-
-	return nameserver.BuildRecordEvent(act, tid, aid, ip, port, weight, false)
-}
-
-func genJanitorBackendEvent(taskEv *types.TaskEvent) *upstream.BackendEvent {
-	var (
-		act string
-
-		// upstream
-		ups    = taskEv.AppID
-		alias  = taskEv.AppAlias
-		listen = "" // TODO
-
-		// backend
-		backend = taskEv.TaskID
-		ip      = taskEv.IP
-		port    = taskEv.Port
-		weight  = taskEv.Weight
-		version = taskEv.VersionID
-	)
-
-	switch taskEv.Type {
-	case types.EventTypeTaskHealthy:
-		act = "add"
-	case types.EventTypeTaskUnhealthy:
-		act = "del"
-	case types.EventTypeTaskWeightChange:
-		act = "change"
-	default:
-		return nil
-	}
-
-	return upstream.BuildBackendEvent(act, ups, alias, listen, backend, ip, version, port, weight)
 }

--- a/agent/api.go
+++ b/agent/api.go
@@ -30,8 +30,12 @@ func (agent *Agent) NewHTTPMux() http.Handler {
 
 	// /dns/**
 	r = mux.Group("/dns")
-	r.GET("", resolver.ListAllRecords)
+	r.GET("", resolver.ListRecords)
+	r.GET("/records", resolver.ListRecords)
+	r.PUT("/records", resolver.UpsertRecord)
+	r.DELETE("/records", resolver.DelRecord)
 	r.GET("/configs", resolver.ShowConfigs)
+	r.GET("/stats", resolver.ShowStats)
 
 	mux.NoRoute(agent.serveProxy)
 	return mux

--- a/agent/janitor/api.go
+++ b/agent/janitor/api.go
@@ -54,11 +54,10 @@ func (s *JanitorServer) ShowConfigs(c *gin.Context) {
 
 func (s *JanitorServer) ShowStats(c *gin.Context) {
 	wrapper := map[string]interface{}{
-		"httpd":          s.config.ListenAddr,
-		"httpdTLS":       s.config.TLSListenAddr,
-		"queuing_events": len(s.eventChan),
-		"counter":        stats.Get(),
-		"tcpd":           s.tcpd,
+		"httpd":    s.config.ListenAddr,
+		"httpdTLS": s.config.TLSListenAddr,
+		"counter":  stats.Get(),
+		"tcpd":     s.tcpd,
 	}
 	c.JSON(200, wrapper)
 }

--- a/agent/janitor/docs/api.md
+++ b/agent/janitor/docs/api.md
@@ -190,7 +190,6 @@
   },
   "httpd": ":80",
   "httpdTLS": "",
-  "queuing_events": 0,
   "tcpd": {            // 4层TCP代理  
     ":81": {           // 监听端口
       "active_clients": 1,  // 当前在线连接数

--- a/agent/janitor/upstream/upstream.go
+++ b/agent/janitor/upstream/upstream.go
@@ -106,51 +106,6 @@ func (b *Backend) Addr() string {
 	return fmt.Sprintf("%s:%d", b.IP, b.Port)
 }
 
-// BackendEvent
-type BackendEvent struct {
-	Action string // add/del/update
-	*BackendCombined
-}
-
-func (ev *BackendEvent) String() string {
-	return fmt.Sprintf("{%s upstream:%s backend:%s addr:%s:%d weight:%f}",
-		ev.Action, ev.Upstream.Name, ev.Backend.ID,
-		ev.Backend.IP, ev.Backend.Port, ev.Backend.Weight)
-}
-
-func (ev *BackendEvent) Format() {
-	// rewrite Upstream.Listen
-	ev.Upstream.Listen = ev.Upstream.tcpListen()
-
-	// rewrite backend clean name
-	fields := strings.SplitN(ev.Backend.ID, ".", 2)
-	if len(fields) == 2 {
-		ev.Backend.CleanName = fields[1]
-	}
-}
-
-func BuildBackendEvent(act, ups, alias, listen, backend, ip, ver string, port uint64, weight float64) *BackendEvent {
-	return &BackendEvent{
-		Action: act,
-		BackendCombined: &BackendCombined{
-			Upstream: &Upstream{
-				Name:   ups,
-				Alias:  alias,
-				Listen: listen,
-			},
-			Backend: &Backend{
-				ID:        backend,
-				IP:        ip,
-				Port:      port,
-				Scheme:    "",
-				Version:   ver,
-				Weight:    weight,
-				CleanName: "",
-			},
-		},
-	}
-}
-
 // BackendCombined
 type BackendCombined struct {
 	*Upstream `json:"upstream"`
@@ -171,6 +126,17 @@ func (cmb *BackendCombined) Valid() error {
 		return errors.New("backend name must be suffixed by upstream name")
 	}
 	return nil
+}
+
+func (cmb *BackendCombined) Format() {
+	// rewrite Upstream.Listen
+	cmb.Upstream.Listen = cmb.Upstream.tcpListen()
+
+	// rewrite backend clean name
+	fields := strings.SplitN(cmb.Backend.ID, ".", 2)
+	if len(fields) == 2 {
+		cmb.Backend.CleanName = fields[1]
+	}
 }
 
 // Exported Functions ....

--- a/agent/nameserver/api.go
+++ b/agent/nameserver/api.go
@@ -1,11 +1,45 @@
 package nameserver
 
-import "github.com/gin-gonic/gin"
+import (
+	"net/http"
 
-func (s *Resolver) ListAllRecords(c *gin.Context) {
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Resolver) ListRecords(c *gin.Context) {
 	c.JSON(200, s.allRecords())
+}
+
+func (s *Resolver) UpsertRecord(c *gin.Context) {
+	var record *Record
+	if err := c.BindJSON(&record); err != nil {
+		http.Error(c.Writer, err.Error(), 400)
+		return
+	}
+
+	if err := s.upsert(record); err != nil {
+		http.Error(c.Writer, err.Error(), 500)
+		return
+	}
+
+	c.Writer.WriteHeader(201)
+
+}
+
+func (s *Resolver) DelRecord(c *gin.Context) {
+	var record *Record
+	if err := c.BindJSON(&record); err != nil {
+		http.Error(c.Writer, err.Error(), 400)
+		return
+	}
+
+	s.remove(record)
+	c.Writer.WriteHeader(204)
 }
 
 func (s *Resolver) ShowConfigs(c *gin.Context) {
 	c.JSON(200, s.config)
+}
+
+func (s *Resolver) ShowStats(c *gin.Context) {
 }

--- a/agent/nameserver/records.go
+++ b/agent/nameserver/records.go
@@ -50,13 +50,13 @@ type Record struct {
 func (r *Record) rewrite(base string) error {
 	ip := net.ParseIP(r.IP)
 	if ip == nil {
-		return errors.New("invlaid IP: " + r.IP)
+		return errors.New("dns-record: invlaid IP: " + r.IP)
 	}
 	r.ip = ip
 
 	port, err := strconv.Atoi(r.Port)
 	if err != nil {
-		return errors.New("invalid Port: " + r.Port)
+		return errors.New("dns-record: invalid Port: " + r.Port)
 	}
 	r.portN = port
 

--- a/agent/nameserver/records.go
+++ b/agent/nameserver/records.go
@@ -1,7 +1,6 @@
 package nameserver
 
 import (
-	"encoding/json"
 	"errors"
 	"net"
 	"strconv"
@@ -9,30 +8,6 @@ import (
 
 	"github.com/miekg/dns"
 )
-
-type RecordEvent struct {
-	Action string
-	Record
-}
-
-func (ev *RecordEvent) String() string {
-	bs, _ := json.Marshal(ev)
-	return string(bs)
-}
-
-func BuildRecordEvent(act, id, parent, ip, port string, weight float64, isProxyRecord bool) *RecordEvent {
-	return &RecordEvent{
-		Action: act,
-		Record: Record{
-			ID:          id,
-			Parent:      parent,
-			IP:          ip,
-			Port:        port,
-			Weight:      weight,
-			ProxyRecord: isProxyRecord,
-		},
-	}
-}
 
 type Record struct {
 	ID          string  `json:"id"`

--- a/agent/nameserver/resolver.go
+++ b/agent/nameserver/resolver.go
@@ -93,7 +93,7 @@ func (r *Resolver) allRecords() map[string][]*Record {
 	return r.m
 }
 
-func (r *Resolver) upsert(record *Record) {
+func (r *Resolver) upsert(record *Record) error {
 	var (
 		parent = record.Parent
 		id     = record.ID
@@ -102,7 +102,7 @@ func (r *Resolver) upsert(record *Record) {
 	// verify & rewrite
 	if err := record.rewrite(r.base); err != nil {
 		log.Warnf("resolver veriy & rewrite record error: %v", err)
-		return
+		return err
 	}
 
 	r.Lock()
@@ -111,7 +111,7 @@ func (r *Resolver) upsert(record *Record) {
 	records, ok := r.m[parent]
 	if !ok {
 		r.m[parent] = []*Record{record}
-		return
+		return nil
 	}
 
 	var idx int = -1
@@ -123,10 +123,11 @@ func (r *Resolver) upsert(record *Record) {
 	}
 
 	if idx >= 0 {
-		return
+		return nil
 	}
 
 	r.m[parent] = append(r.m[parent], record)
+	return nil
 }
 
 func (r *Resolver) remove(record *Record) {

--- a/agent/nameserver/resolver.go
+++ b/agent/nameserver/resolver.go
@@ -31,7 +31,7 @@ type Resolver struct {
 	forwardAddrs []string             // for forwarders
 }
 
-func NewResolver(cfg *config.DNS) *Resolver {
+func NewResolver(cfg *config.DNS, AdvertiseIP string) *Resolver {
 	base := cfg.Domain
 	if !strings.HasSuffix(base, ".") {
 		base = base + "."
@@ -49,6 +49,17 @@ func NewResolver(cfg *config.DNS) *Resolver {
 			WriteTimeout: cfg.ExchangeTimeout,
 		},
 	}
+
+	// init with local proxy dns record
+	rr := &Record{
+		ID:          "local_proxy",
+		Parent:      "PROXY",
+		IP:          AdvertiseIP, // we've verified before
+		Port:        "80",
+		Weight:      0,
+		ProxyRecord: true,
+	}
+	resolver.upsert(rr)
 
 	resolver.forwardAddrs = make([]string, len(cfg.Resolvers))
 	for i, addr := range cfg.Resolvers {

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -11,14 +11,14 @@ import (
 )
 
 func (r *Router) listAgents(w http.ResponseWriter, req *http.Request) {
-	ret := r.master.Agents()
+	ret := r.driver.ClusterAgents()
 	writeJSON(w, http.StatusOK, ret)
 }
 
 func (r *Router) getAgent(w http.ResponseWriter, req *http.Request) {
 	var (
 		id    = mux.Vars(req)["agent_id"]
-		agent = r.master.Agent(id)
+		agent = r.driver.ClusterAgent(id)
 	)
 
 	if agent == nil {
@@ -48,7 +48,7 @@ func (r *Router) redirectAgentDNS(w http.ResponseWriter, req *http.Request) {
 func (r *Router) redirectAgent(stripN int, w http.ResponseWriter, req *http.Request) {
 	var (
 		id    = mux.Vars(req)["agent_id"]
-		agent = r.master.Agent(id)
+		agent = r.driver.ClusterAgent(id)
 	)
 
 	if agent == nil {
@@ -78,7 +78,7 @@ func (r *Router) proxyAgentHandle(id string, req *http.Request, w http.ResponseW
 }
 
 func (r *Router) proxyAgent(id string, req *http.Request) (*http.Response, error) {
-	agent := r.master.Agent(id)
+	agent := r.driver.ClusterAgent(id)
 	if agent == nil {
 		return nil, errors.New("no such agent: " + id)
 	}

--- a/api/driver.go
+++ b/api/driver.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/Dataman-Cloud/swan/mesos"
+	"github.com/Dataman-Cloud/swan/mole"
 	"github.com/Dataman-Cloud/swan/types"
 )
 
@@ -15,6 +16,9 @@ type Driver interface {
 
 	SubscribeEvent(http.ResponseWriter, string) error
 	TaskEvents() []*types.TaskEvent
+
+	ClusterAgents() map[string]*mole.ClusterAgent
+	ClusterAgent(id string) *mole.ClusterAgent
 
 	// for debug convenience
 	Dump() interface{}

--- a/api/router.go
+++ b/api/router.go
@@ -1,22 +1,17 @@
 package api
 
-import (
-	"github.com/Dataman-Cloud/swan/mole"
-	. "github.com/Dataman-Cloud/swan/store"
-)
+import . "github.com/Dataman-Cloud/swan/store"
 
 type Router struct {
 	routes []*Route
 	driver Driver
 	db     Store
-	master *mole.Master
 }
 
-func NewRouter(d Driver, s Store, master *mole.Master) *Router {
+func NewRouter(d Driver, s Store) *Router {
 	r := &Router{
 		driver: d,
 		db:     s,
-		master: master,
 	}
 
 	r.setupRoutes()

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,13 @@ func NewAgentConfig(c *cli.Context) (AgentConfig, error) {
 		}
 	}
 
+	// verify AdvertiseIP is valid ipaddr
+	if ip := cfg.Janitor.AdvertiseIP; ip != "" {
+		if net.ParseIP(ip) == nil {
+			return cfg, fmt.Errorf("invalid advertise ip: %v", ip)
+		}
+	}
+
 	if c.String("gateway-tls-listen-addr") != "" {
 		cfg.Janitor.TLSListenAddr = c.String("gateway-tls-listen-addr")
 	}

--- a/mesos/cluster.go
+++ b/mesos/cluster.go
@@ -1,0 +1,144 @@
+package mesos
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
+
+	"github.com/Dataman-Cloud/swan/agent/janitor/upstream"
+	"github.com/Dataman-Cloud/swan/agent/nameserver"
+	"github.com/Dataman-Cloud/swan/mole"
+	"github.com/Dataman-Cloud/swan/types"
+)
+
+func (s *Scheduler) ClusterAgents() map[string]*mole.ClusterAgent {
+	return s.clusterMaster.Agents()
+}
+
+func (s *Scheduler) ClusterAgent(id string) *mole.ClusterAgent {
+	return s.clusterMaster.Agent(id)
+}
+
+type broadcastRes struct {
+	sync.Mutex
+	m [][2]string // agent-id, errmsg
+}
+
+func (br *broadcastRes) Error() string {
+	bs, _ := json.Marshal(br.m)
+	return string(bs)
+}
+
+// sync calling agent Api to update agent's proxy & dns records on task healthy events.
+func (s *Scheduler) broadcastEventRecords(ev *types.TaskEvent) error {
+	reqProxy, err := s.buildAgentProxyReq(ev)
+	if err != nil {
+		return err
+	}
+
+	reqDNS, err := s.buildAgentDNSReq(ev)
+	if err != nil {
+		return err
+	}
+
+	res := &broadcastRes{m: make([][2]string, 0, 0)}
+
+	var wg sync.WaitGroup
+	for _, agent := range s.ClusterAgents() {
+		wg.Add(1)
+		go func(agent *mole.ClusterAgent) {
+			defer wg.Done()
+
+			for _, req := range []*http.Request{reqProxy, reqDNS} {
+				resp, err := agent.Client().Do(req)
+				if err != nil {
+					res.Lock()
+					res.m = append(res.m, [2]string{agent.ID(), err.Error()})
+					res.Unlock()
+					continue
+				}
+
+				if code := resp.StatusCode; code >= 400 {
+					bs, _ := ioutil.ReadAll(resp.Body)
+					res.Lock()
+					res.m = append(res.m, [2]string{agent.ID(), fmt.Sprintf("%d - %s", code, string(bs))})
+					res.Unlock()
+				}
+
+				resp.Body.Close()
+			}
+		}(agent)
+	}
+
+	wg.Wait()
+
+	if len(res.m) == 0 {
+		return nil
+	}
+
+	return res
+}
+
+func (s *Scheduler) buildAgentDNSReq(ev *types.TaskEvent) (*http.Request, error) {
+	body := &nameserver.Record{
+		ID:          ev.TaskID,
+		Parent:      ev.AppID,
+		IP:          ev.IP,
+		Port:        fmt.Sprintf("%d", ev.Port),
+		Weight:      ev.Weight,
+		ProxyRecord: false,
+	}
+
+	bs, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	switch typ := ev.Type; typ {
+	case types.EventTypeTaskHealthy:
+		return http.NewRequest("PUT", "http://xxx/dns/records", bytes.NewBuffer(bs))
+	case types.EventTypeTaskUnhealthy:
+		return http.NewRequest("DELETE", "http://xxx/dns/records", bytes.NewBuffer(bs))
+	case types.EventTypeTaskWeightChange:
+		return nil, nil
+	default:
+		return nil, errors.New("unknown event type: " + typ)
+	}
+}
+
+func (s *Scheduler) buildAgentProxyReq(ev *types.TaskEvent) (*http.Request, error) {
+	body := &upstream.BackendCombined{
+		Upstream: &upstream.Upstream{
+			Name:   ev.AppID,
+			Alias:  ev.AppAlias,
+			Listen: "", // TODO
+		},
+		Backend: &upstream.Backend{
+			ID:        ev.TaskID,
+			IP:        ev.IP,
+			Port:      ev.Port,
+			Scheme:    "",
+			Version:   ev.VersionID,
+			Weight:    ev.Weight,
+			CleanName: "",
+		},
+	}
+
+	bs, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	switch typ := ev.Type; typ {
+	case types.EventTypeTaskHealthy, types.EventTypeTaskWeightChange:
+		return http.NewRequest("PUT", "http://xxx/proxy/upstreams", bytes.NewBuffer(bs))
+	case types.EventTypeTaskUnhealthy:
+		return http.NewRequest("DELETE", "http://xxx/proxy/upstreams", bytes.NewBuffer(bs))
+	default:
+		return nil, errors.New("unknown event type: " + typ)
+	}
+}

--- a/mesos/handler.go
+++ b/mesos/handler.go
@@ -162,7 +162,7 @@ func (s *Scheduler) updateHandler(event *mesosproto.Event) {
 		proxyEnabled = ver.Proxy.Enabled
 	}
 
-	if err := s.eventmgr.broadcast(&types.TaskEvent{
+	taskEv := &types.TaskEvent{
 		Type:           evType,
 		AppID:          appId,
 		AppAlias:       alias,
@@ -171,8 +171,15 @@ func (s *Scheduler) updateHandler(event *mesosproto.Event) {
 		Port:           task.Port,
 		Weight:         task.Weight,
 		GatewayEnabled: proxyEnabled,
-	}); err != nil {
-		log.Errorf("broadcast task event got error: %v", err)
+	}
+
+	if err := s.eventmgr.broadcast(taskEv); err != nil {
+		log.Errorln("broadcast task event got error:", err)
+	}
+
+	if err := s.broadcastEventRecords(taskEv); err != nil {
+		log.Errorln("broadcast to sync proxy & dns records error:", err)
+		// TODO: memo db task errmsg
 	}
 
 	return

--- a/mesos/scheduler.go
+++ b/mesos/scheduler.go
@@ -16,6 +16,7 @@ import (
 
 	mesos "github.com/Dataman-Cloud/swan/mesos/offer"
 	"github.com/Dataman-Cloud/swan/mesosproto"
+	"github.com/Dataman-Cloud/swan/mole"
 	"github.com/Dataman-Cloud/swan/store"
 	"github.com/Dataman-Cloud/swan/types"
 )
@@ -77,6 +78,8 @@ type Scheduler struct {
 
 	eventmgr *eventManager
 
+	clusterMaster *mole.Master
+
 	launch sync.Mutex
 
 	status string
@@ -85,18 +88,19 @@ type Scheduler struct {
 }
 
 // NewScheduler...
-func NewScheduler(cfg *SchedulerConfig, db store.Store, strategy Strategy, mgr *eventManager) (*Scheduler, error) {
+func NewScheduler(cfg *SchedulerConfig, db store.Store, strategy Strategy, clusterMaster *mole.Master) (*Scheduler, error) {
 	s := &Scheduler{
-		cfg:          cfg,
-		framework:    defaultFramework(),
-		quit:         make(chan struct{}),
-		agents:       make(map[string]*Agent),
-		tasks:        make(map[string]*Task),
-		offerTimeout: time.Duration(10 * time.Second),
-		db:           db,
-		strategy:     strategy,
-		filters:      make([]Filter, 0),
-		eventmgr:     mgr,
+		cfg:           cfg,
+		framework:     defaultFramework(),
+		quit:          make(chan struct{}),
+		agents:        make(map[string]*Agent),
+		tasks:         make(map[string]*Task),
+		offerTimeout:  time.Duration(10 * time.Second),
+		db:            db,
+		strategy:      strategy,
+		filters:       make([]Filter, 0),
+		eventmgr:      NewEventManager(),
+		clusterMaster: clusterMaster,
 	}
 
 	if err := s.init(); err != nil {

--- a/mole/master.go
+++ b/mole/master.go
@@ -139,6 +139,10 @@ type ClusterAgent struct {
 	lastActive time.Time
 }
 
+func (ca *ClusterAgent) ID() string {
+	return ca.id
+}
+
 // Dial specifies the dial function for creating unencrypted TCP connections within the http.Client
 func (ca *ClusterAgent) Dial(network, addr string) (net.Conn, error) {
 	wid := randNumber(10)


### PR DESCRIPTION
去掉agent中的event订阅的逻辑和相关代码，dns／proxy数据由manager同步更新，并纪录失败信息。
完成 #662  中的 `同步方式更新proxy纪录`