### PR TITLE
full sync swan manager's dns & proxy records on swan agent start up

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -47,8 +47,17 @@ func (agent *Agent) StartAndJoin() error {
 	}
 
 	// startup resolver & janitor
-	go agent.resolver.Start()
-	go agent.janitor.Start()
+	go func() {
+		if err := agent.resolver.Start(); err != nil {
+			log.Fatalln("resolver occured fatal error:", err)
+		}
+	}()
+
+	go func() {
+		if err := agent.janitor.Start(); err != nil {
+			log.Fatalln("janitor occured fatal error:", err)
+		}
+	}()
 
 	// serving protocol & Api with underlying mole
 	var (

--- a/agent/janitor/api.go
+++ b/agent/janitor/api.go
@@ -25,7 +25,7 @@ func (s *JanitorServer) UpsertUpstream(c *gin.Context) {
 		return
 	}
 
-	if err := s.upsertBackend(cmb); err != nil {
+	if err := s.UpsertBackend(cmb); err != nil {
 		http.Error(c.Writer, err.Error(), 500)
 		return
 	}

--- a/agent/janitor/janitor.go
+++ b/agent/janitor/janitor.go
@@ -66,7 +66,7 @@ func (s *JanitorServer) Start() error {
 	return <-errCh
 }
 
-func (s *JanitorServer) upsertBackend(cmb *upstream.BackendCombined) error {
+func (s *JanitorServer) UpsertBackend(cmb *upstream.BackendCombined) error {
 	if err := cmb.Valid(); err != nil {
 		return err
 	}

--- a/agent/resolver/api.go
+++ b/agent/resolver/api.go
@@ -17,7 +17,7 @@ func (s *Resolver) UpsertRecord(c *gin.Context) {
 		return
 	}
 
-	if err := s.upsert(record); err != nil {
+	if err := s.Upsert(record); err != nil {
 		http.Error(c.Writer, err.Error(), 500)
 		return
 	}

--- a/agent/resolver/resolver.go
+++ b/agent/resolver/resolver.go
@@ -59,7 +59,7 @@ func NewResolver(cfg *config.DNS, AdvertiseIP string) *Resolver {
 		Weight:      0,
 		ProxyRecord: true,
 	}
-	resolver.upsert(rr)
+	resolver.Upsert(rr)
 
 	resolver.forwardAddrs = make([]string, len(cfg.Resolvers))
 	for i, addr := range cfg.Resolvers {
@@ -80,7 +80,7 @@ func (r *Resolver) allRecords() map[string][]*Record {
 	return r.m
 }
 
-func (r *Resolver) upsert(record *Record) error {
+func (r *Resolver) Upsert(record *Record) error {
 	var (
 		parent = record.Parent
 		id     = record.ID

--- a/agent/sync.go
+++ b/agent/sync.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/Dataman-Cloud/swan/types"
+)
+
+func (agent *Agent) syncFull(addr string) error {
+	if !strings.HasPrefix(addr, "http://") {
+		addr = "http://" + addr
+	}
+	addr += "/v1/fullsync"
+
+	resp, err := http.Get(addr)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var full []*types.CombinedEvents
+	if err := json.NewDecoder(resp.Body).Decode(&full); err != nil {
+		return err
+	}
+
+	log.Printf("full syncing %d dns & proxy records ...", len(full))
+
+	for _, cmb := range full {
+		var (
+			proxy = cmb.Proxy
+			dns   = cmb.DNS
+		)
+
+		if err := agent.resolver.Upsert(dns); err != nil {
+			log.Errorln("upsert dns record error:", err)
+			return err
+		}
+
+		if err := agent.janitor.UpsertBackend(proxy); err != nil {
+			log.Errorln("upsert proxy record error:", err)
+			return err
+		}
+	}
+
+	log.Println("full sync dns & proxy records succeed")
+	return nil
+}

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -30,6 +30,11 @@ func (r *Router) getAgent(w http.ResponseWriter, req *http.Request) {
 	r.proxyAgentHandle(id, agentReq, w)
 }
 
+func (r *Router) fullEventsAndRecords(w http.ResponseWriter, req *http.Request) {
+	ret := r.driver.FullTaskEventsAndRecords()
+	writeJSON(w, http.StatusOK, ret)
+}
+
 func (r *Router) redirectAgentDocker(w http.ResponseWriter, req *http.Request) {
 	n := len(`/v1/agents/docker/`) + 16
 	r.redirectAgent(n, w, req)

--- a/api/driver.go
+++ b/api/driver.go
@@ -15,7 +15,7 @@ type Driver interface {
 	ClusterName() string
 
 	SubscribeEvent(http.ResponseWriter, string) error
-	TaskEvents() []*types.TaskEvent
+	FullTaskEventsAndRecords() []*types.CombinedEvents
 
 	ClusterAgents() map[string]*mole.ClusterAgent
 	ClusterAgent(id string) *mole.ClusterAgent

--- a/api/event.go
+++ b/api/event.go
@@ -23,8 +23,8 @@ func (r *Router) events(w http.ResponseWriter, req *http.Request) {
 
 	// notify new client all of current tasks' stats throught sse firstly
 	if catchUp := req.Form.Get("catchUp"); strings.ToLower(catchUp) == "true" {
-		for _, ev := range r.driver.TaskEvents() {
-			if _, err := w.Write(ev.Format()); err != nil {
+		for _, cmbEv := range r.driver.FullTaskEventsAndRecords() {
+			if _, err := w.Write(cmbEv.Event.Format()); err != nil {
 				log.Errorf("write event message to client [%s] error: [%v]", req.RemoteAddr, err)
 				continue
 			}

--- a/api/router.go
+++ b/api/router.go
@@ -60,6 +60,7 @@ func (r *Router) setupRoutes() {
 		NewRoute("DELETE", "/v1/purge", r.purge),
 
 		NewRoute("GET", "/v1/debug/dump", r.dump),
+		NewRoute("GET", "/v1/fullsync", r.fullEventsAndRecords),
 
 		NewRoute("GET", "/v1/agents", r.listAgents),
 		NewRoute("GET", "/v1/agents/{agent_id}", r.getAgent),

--- a/mesos/cluster.go
+++ b/mesos/cluster.go
@@ -83,8 +83,8 @@ func (s *Scheduler) broadcastEventRecords(ev *types.TaskEvent) error {
 	return res
 }
 
-func (s *Scheduler) buildAgentDNSReq(ev *types.TaskEvent) (*http.Request, error) {
-	body := &resolver.Record{
+func (s *Scheduler) buildAgentDNSRecord(ev *types.TaskEvent) *resolver.Record {
+	return &resolver.Record{
 		ID:          ev.TaskID,
 		Parent:      ev.AppID,
 		IP:          ev.IP,
@@ -92,6 +92,10 @@ func (s *Scheduler) buildAgentDNSReq(ev *types.TaskEvent) (*http.Request, error)
 		Weight:      ev.Weight,
 		ProxyRecord: false,
 	}
+}
+
+func (s *Scheduler) buildAgentDNSReq(ev *types.TaskEvent) (*http.Request, error) {
+	body := s.buildAgentDNSRecord(ev)
 
 	bs, err := json.Marshal(body)
 	if err != nil {
@@ -110,8 +114,8 @@ func (s *Scheduler) buildAgentDNSReq(ev *types.TaskEvent) (*http.Request, error)
 	}
 }
 
-func (s *Scheduler) buildAgentProxyReq(ev *types.TaskEvent) (*http.Request, error) {
-	body := &upstream.BackendCombined{
+func (s *Scheduler) buildAgentProxyRecord(ev *types.TaskEvent) *upstream.BackendCombined {
+	return &upstream.BackendCombined{
 		Upstream: &upstream.Upstream{
 			Name:   ev.AppID,
 			Alias:  ev.AppAlias,
@@ -127,6 +131,10 @@ func (s *Scheduler) buildAgentProxyReq(ev *types.TaskEvent) (*http.Request, erro
 			CleanName: "",
 		},
 	}
+}
+
+func (s *Scheduler) buildAgentProxyReq(ev *types.TaskEvent) (*http.Request, error) {
+	body := s.buildAgentProxyRecord(ev)
 
 	bs, err := json.Marshal(body)
 	if err != nil {

--- a/types/event.go
+++ b/types/event.go
@@ -3,6 +3,9 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/Dataman-Cloud/swan/agent/janitor/upstream"
+	"github.com/Dataman-Cloud/swan/agent/resolver"
 )
 
 const (
@@ -10,6 +13,12 @@ const (
 	EventTypeTaskWeightChange = "task_weight_change"
 	EventTypeTaskUnhealthy    = "task_unhealthy"
 )
+
+type CombinedEvents struct {
+	Event *TaskEvent
+	Proxy *upstream.BackendCombined // built from event
+	DNS   *resolver.Record          // built from event
+}
 
 type TaskEvent struct {
 	Type           string  `json:"type"`


### PR DESCRIPTION
  - agent 启动时候先同步 manager 上所有的 dns & proxy 数据到本地内存。
  - proxy／dns 退出则 agent 直接退出。