### PR TITLE
agent only join to swan leader manager

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -216,7 +216,9 @@ func (m *Manager) start() error {
 				}
 
 				m.apiserver.Update(m.leader)
+
 			case LeadershipFollower:
+				m.clusterMaster.CloseAllAgents()
 				m.apiserver.Update(m.leader)
 			}
 

--- a/mole/master.go
+++ b/mole/master.go
@@ -99,6 +99,12 @@ func (m *Master) AddAgent(id string, conn net.Conn) {
 	m.agents[id] = ca
 }
 
+func (m *Master) CloseAllAgents() {
+	for id := range m.Agents() {
+		m.CloseAgent(id)
+	}
+}
+
 func (m *Master) CloseAgent(id string) {
 	m.Lock()
 	defer m.Unlock()


### PR DESCRIPTION
修复：
  - swan agent 启动时候只 join swan master 的 leader 节点
  - swan manager 切换 leader后，断开agent 连接，使 agent 重新 rejoin，agent本地 proxy / dns 不受影响