### PR TITLE
add scale policy

### DIFF
--- a/docs/scale.md
+++ b/docs/scale.md
@@ -1,0 +1,22 @@
+#### Scale Policy
+
+Spec 
+```
+{
+    "instances": 100,
+    "ips": ['192.168.1.100', '192.168.1.101', '192.168.1.102'],
+    "step": 10,
+    "onfailure": "continue"
+}
+
+```
+
+Json Parameters:
++ *instances*(int): The goal to scale up/down.
++ *ips*(array): IP list for static ip(brige or host or scale down ignore).
++ *step*(int): The number of tasks to run at one time for scale up.
++ *onfailure*(string): The action for failure. Possible values include:
+```
+stop
+continue
+```

--- a/example/scale.json
+++ b/example/scale.json
@@ -1,3 +1,6 @@
 {
-	"instances": 6
+    "instances": 100, 
+    "ips":[],
+    "step": 10,
+    "onfailure": "continue"
 }

--- a/types/opt.go
+++ b/types/opt.go
@@ -1,10 +1,5 @@
 package types
 
-type ScaleBody struct {
-	Instances int      `json:"instances"`
-	IPs       []string `json:"ips"` // TODO(nmg): Removed after automatic IPAM.
-}
-
 type UpdateBody struct {
 	Instances int     `json:"instances"`
 	Canary    *canary `json:"canary"`

--- a/types/scale.go
+++ b/types/scale.go
@@ -1,0 +1,13 @@
+package types
+
+const (
+	ScaleFailureStop     = "stop"
+	ScaleFailureContinue = "continue"
+)
+
+type ScalePolicy struct {
+	Instances int
+	IPs       []string
+	Step      int
+	OnFailure string
+}


### PR DESCRIPTION
 + 添加了扩缩策略
```
{
    "instances": 100,
    "ips":[],
    "step": 10,
    "onfailure": "continue"
}
```
+ `step` : 指定了scale up时的步长
+ `onfailure`: 指定了scale up发生错误时的动作，动作有两种, 停止(`stop`) 或继续(`continue`), 
    默认是`continue`.