### PR TITLE
compitable for legacy docker version build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,22 @@ default: build
 build: clean
 	go build -ldflags "${GO_LDFLAGS}" -o bin/swan main.go
 
+# multi-stage builds, require docker >= 17.05
 docker:
 	docker build --tag swan:$(shell git rev-parse --short HEAD) --rm .
 
+# multi-stage builds, require docker >= 17.05
 docker-centos:
 	docker build --tag swan:$(shell git rev-parse --short HEAD) --rm -f ./Dockerfile.centos .
+
+# compitable for legacy docker version
+docker-build:
+	docker run --rm \
+		-w /go/src/github.com/Dataman-Cloud/swan \
+		-e CGO_ENABLED=0 -e GOOS=linux -e GOARCH=amd64  \
+		-v $(shell pwd):/go/src/github.com/Dataman-Cloud/swan \
+		golang:1.8.1-alpine \
+		sh -c 'go build -ldflags "${GO_LDFLAGS}" -v -o bin/swan main.go'
 
 clean:
 	rm -rfv bin/*


### PR DESCRIPTION
部分开发环境， 测试jenkins环境的docker版本 无法使用 `multi-stage builds`
旧版本 docker 可以继续使用 `make docker-build` 来构建二进制
