### PR TITLE
compitable for legacy docker version image build

### DIFF
--- a/Dockerfile.legacy
+++ b/Dockerfile.legacy
@@ -1,0 +1,4 @@
+FROM alpine:3.5
+WORKDIR /root/
+COPY bin/swan /root/swan
+ENTRYPOINT ["./swan"]

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ docker-build:
 		golang:1.8.1-alpine \
 		sh -c 'go build -ldflags "${GO_LDFLAGS}" -v -o bin/swan main.go'
 
+# compitable for legacy docker version
+docker-image:
+	docker build --tag swan:$(shell git rev-parse --short HEAD) --rm -f ./Dockerfile.legacy .
+
 clean:
 	rm -rfv bin/*
 


### PR DESCRIPTION
similar to #780 
旧版本 docker 使用 `make docker-image` 来构建镜像