### PR TITLE
tuning on framework settings to speed up mesos events

### DIFF
--- a/mesos/framework.go
+++ b/mesos/framework.go
@@ -34,7 +34,6 @@ func defaultFramework() *mesosproto.FrameworkInfo {
 		Hostname:        proto.String(hostName),
 		Capabilities: []*mesosproto.FrameworkInfo_Capability{
 			{Type: mesosproto.FrameworkInfo_Capability_PARTITION_AWARE.Enum()},
-			{Type: mesosproto.FrameworkInfo_Capability_TASK_KILLING_STATE.Enum()},
 		},
 	}
 }


### PR DESCRIPTION
测试中发现这些参数非常影响mesos evnet的返回速度，先去掉

replaced by #813  make it optional, default disabled.