### PR TITLE
set mesos `Capability_TASK_KILLING` to optional to avoid task killed …

### DIFF
--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -92,6 +92,15 @@ func FlagMaxTasksPerOffer() cli.Flag {
 	}
 }
 
+func FlagEnableCapabilityKilling() cli.Flag {
+	return cli.StringFlag{
+		Name:   "enable-capability-killing",
+		Usage:  "To enable TASK_KILLING state in Mesos (0.28 or later)",
+		EnvVar: "SWAN_ENABLE_CAPABILITY_KILLING",
+		Value:  "false",
+	}
+}
+
 func FlagJoinAddrs() cli.Flag {
 	return cli.StringFlag{
 		Name:   "join-addrs",

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -31,6 +31,7 @@ func ManagerCmd() cli.Command {
 		FlagReconciliationStepDelay(),
 		FlagHeartbeatTimeout(),
 		FlagMaxTasksPerOffer(),
+		FlagEnableCapabilityKilling(),
 	}
 
 	return cmd

--- a/config/manager.go
+++ b/config/manager.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/urfave/cli"
@@ -26,6 +27,7 @@ type ManagerConfig struct {
 	ReconciliationStepDelay float64 `json:"reconciliationStepDelay"`
 	HeartbeatTimeout        float64 `json:"heartbeatTimeout"`
 	MaxTasksPerOffer        int     `json:"maxTasksPerOffer"`
+	EnableCapabilityKilling bool    `json:"enableCapabilityKilling"`
 }
 
 func NewManagerConfig(c *cli.Context) (*ManagerConfig, error) {
@@ -84,6 +86,10 @@ func NewManagerConfig(c *cli.Context) (*ManagerConfig, error) {
 
 	if max := c.Int("max-tasks-per-offer"); max != 0 {
 		cfg.MaxTasksPerOffer = max
+	}
+
+	if killing := c.String("enable-capability-killing"); killing != "" {
+		cfg.EnableCapabilityKilling, _ = strconv.ParseBool(killing)
 	}
 
 	if err := cfg.validate(); err != nil {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -61,6 +61,7 @@ func New(cfg *config.ManagerConfig) (*Manager, error) {
 		ReconciliationStepDelay: cfg.ReconciliationStepDelay,
 		HeartbeatTimeout:        cfg.HeartbeatTimeout,
 		MaxTasksPerOffer:        cfg.MaxTasksPerOffer,
+		EnableCapabilityKilling: cfg.EnableCapabilityKilling,
 	}
 
 	var s mesos.Strategy

--- a/mesos/framework.go
+++ b/mesos/framework.go
@@ -18,13 +18,13 @@ var (
 	defaultFrameworkCheckpoint      = false
 )
 
-func defaultFramework() *mesosproto.FrameworkInfo {
+func (s *Scheduler) buildFramework() *mesosproto.FrameworkInfo {
 	hostName, err := os.Hostname()
 	if err != nil {
 		hostName = "UNKNOWN"
 	}
 
-	return &mesosproto.FrameworkInfo{
+	fw := &mesosproto.FrameworkInfo{
 		// ID:              proto.String(""), // reset later
 		User:            proto.String(defaultFrameworkUser),
 		Name:            proto.String(defaultFrameworkName),
@@ -34,7 +34,14 @@ func defaultFramework() *mesosproto.FrameworkInfo {
 		Hostname:        proto.String(hostName),
 		Capabilities: []*mesosproto.FrameworkInfo_Capability{
 			{Type: mesosproto.FrameworkInfo_Capability_PARTITION_AWARE.Enum()},
-			{Type: mesosproto.FrameworkInfo_Capability_TASK_KILLING_STATE.Enum()},
 		},
 	}
+
+	if s.cfg.EnableCapabilityKilling {
+		fw.Capabilities = append(fw.Capabilities, &mesosproto.FrameworkInfo_Capability{
+			Type: mesosproto.FrameworkInfo_Capability_TASK_KILLING_STATE.Enum(),
+		})
+	}
+
+	return fw
 }


### PR DESCRIPTION
* 测试发现framework在启用了 `Capability_TASK_KILLING_STATE` 这个capability之后，mesos kill task事件会有延迟。
* 原因是： 当framework设置了这个capability之后， mesos会在kill task之前先发一个TASK_KILLING事件来通知framework, 然后等一定时间之后才去真正杀死task，所以才会感觉删除task慢。marathon默认是没有启用这个特性。
* 该特性可以用来做优雅终止，所以改成可选。

close #810 