### PR TITLE
make clean json output without the tailling newline character

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -9,11 +9,15 @@ import (
 
 // WriteJSON write response as json format.
 func writeJSON(w http.ResponseWriter, code int, v interface{}) {
+	bs, err := json.Marshal(v)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	enc := json.NewEncoder(w)
-	enc.SetEscapeHTML(false)
-	enc.Encode(v)
+	w.Write(bs)
 }
 
 // CheckForJSON makes sure that the request's Content-Type is application/json.


### PR DESCRIPTION
原方法会在数据末尾多一个"\n"，通常用于多条数据流式序列化上，PR修正这个问题。
ping @pwzgorilla 