### PR TITLE
user define networking

### DIFF
--- a/agent/ipam/ipam.go
+++ b/agent/ipam/ipam.go
@@ -2,7 +2,6 @@ package ipam
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -88,8 +87,12 @@ func (m *IPAM) RequestPool(req *ipam.RequestPoolRequest) (*ipam.RequestPoolRespo
 
 	// check if exists
 	if exists, _ := m.store.GetSubNet(subnet.ID); exists != nil {
-		log.Errorln("IPAM RequestPool Conflict on: ", subnet.ID)
-		return nil, errors.New("subnet already exists: " + subnet.ID)
+		log.Println("IPAM RequestPool on the existing subnet: ", subnet.ID)
+		return &ipam.RequestPoolResponse{
+			PoolID: exists.ID,
+			Pool:   exists.CIDR,
+			Data:   nil,
+		}, nil
 	}
 
 	// create kv subnet

--- a/example/static-ip.json
+++ b/example/static-ip.json
@@ -1,0 +1,31 @@
+{
+  "name": "demo",
+  "cmd": "sleep 100d",
+  "cpus": 0.001,
+  "gpus": 0,
+  "mem": 10,
+  "disk": 0,
+  "runAs": "bbk",
+  "priority": 0,
+  "instances": 2,
+  "constraints": [],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "busybox",
+      "network": "swan",
+      "forcePullImage": false,
+      "privileged": false,
+    },
+    "volumes": []
+  },
+  "env": {},
+  "uris": [],
+  "label": {},
+  "healthCheck": {},
+  "proxy": {},
+  "ips": [
+    "192.168.1.199",
+    "192.168.1.200"
+  ]
+}

--- a/types/task.go
+++ b/types/task.go
@@ -179,7 +179,7 @@ func (c *TaskConfig) network() *mesosproto.ContainerInfo_DockerInfo_Network {
 	}
 
 	// mesosproto.ContainerInfo_DockerInfo_USER always lead to error complains:
-	// Failed to run docker container: No network info dound in container info
+	// Failed to run docker container: No network info found in container info
 	// we process user-defined network within parameters().
 	return mesosproto.ContainerInfo_DockerInfo_NONE.Enum()
 }


### PR DESCRIPTION
发应用的自定义容器网络参数不生效，PR修复此问题。
节点上需要依照 #763 提前配置好macvlan容器网络。
且swan agent启动需要 激活 ipam 模块 `--ipam-enabled=true`