### PR TITLE
fix potential panic while get/list on unprepared app

### DIFF
--- a/store/etcd/application.go
+++ b/store/etcd/application.go
@@ -1,6 +1,7 @@
 package etcd
 
 import (
+	"fmt"
 	"path"
 	"sort"
 
@@ -89,6 +90,10 @@ func (s *EtcdStore) GetApp(id string) (*types.Application, error) {
 	if err != nil {
 		log.Errorf("get app %s versions got error: %v", id, err)
 		return nil, err
+	}
+
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("app %s versions temporary not ready", id)
 	}
 
 	app.VersionCount = len(versions)

--- a/store/zk/application.go
+++ b/store/zk/application.go
@@ -79,11 +79,13 @@ func (zk *ZKStore) GetApp(id string) (*types.Application, error) {
 		return nil, err
 	}
 
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("app %s versions temporary not ready", id)
+	}
+
 	if len(app.Version) == 0 {
-		if len(versions) > 0 {
-			types.VersionList(versions).Reverse()
-			app.Version = append(app.Version, versions[0].ID)
-		}
+		types.VersionList(versions).Reverse()
+		app.Version = append(app.Version, versions[0].ID)
 	}
 
 	app.VersionCount = len(versions)


### PR DESCRIPTION
fix #858 
在app创建，version没创建的时候 list app 的API 会panic，PR修复此问题。


