### PR TITLE
ensure the resources value can't be negative

### DIFF
--- a/integration-test/swan_api_create_test.go
+++ b/integration-test/swan_api_create_test.go
@@ -135,4 +135,21 @@ func (s *ApiSuite) TestCreateInvalidApp(c *check.C) {
 	match, _ = regexp.MatchString("should greater than 0", string(body))
 	c.Assert(match, check.Equals, true)
 	fmt.Println("TestCreateInvalidApp() illegal app count verified")
+
+	// invalid resource values
+	var invalidResources = map[*types.Version]string{
+		demoVersion().setCPU(-1).Get():  "cpus can't be negative",
+		demoVersion().setGPU(-1).Get():  "gpus can't be negative",
+		demoVersion().setMem(-1).Get():  "memory can't be negative",
+		demoVersion().setDisk(-1).Get(): "disk can't be negative",
+	}
+	for ver, errmsg := range invalidResources {
+		code, body, err = s.rawCreateApp(ver)
+		c.Assert(err, check.IsNil)
+		c.Assert(code, check.Equals, http.StatusBadRequest)
+		c.Log(string(body))
+		match, _ = regexp.MatchString(errmsg, string(body))
+		c.Assert(match, check.Equals, true)
+	}
+	fmt.Println("TestCreateInvalidApp() illegal resources verified")
 }

--- a/integration-test/swan_api_utils.go
+++ b/integration-test/swan_api_utils.go
@@ -378,6 +378,16 @@ func (b *verBuilder) setCPU(cpu float64) *verBuilder {
 	return b
 }
 
+func (b *verBuilder) setGPU(gpu float64) *verBuilder {
+	b.GPUs = gpu
+	return b
+}
+
+func (b *verBuilder) setDisk(disk float64) *verBuilder {
+	b.Disk = disk
+	return b
+}
+
 func (b *verBuilder) setMem(mem float64) *verBuilder {
 	b.Mem = mem
 	return b
@@ -394,6 +404,7 @@ func demoVersion() *verBuilder {
 		Instances:   int32(1),
 		Command:     "",
 		CPUs:        0.01,
+		GPUs:        0,
 		Mem:         5,
 		Disk:        0,
 		RunAs:       "integration",

--- a/types/version.go
+++ b/types/version.go
@@ -188,6 +188,22 @@ func (v *Version) Validate() error {
 		return errors.New("invalid instances: instances must be specified and should greater than 0")
 	}
 
+	if v.Mem < 0 {
+		return errors.New("memory can't be negative")
+	}
+
+	if v.CPUs < 0 {
+		return errors.New("cpus can't be negative")
+	}
+
+	if v.GPUs < 0 {
+		return errors.New("gpus can't be negative")
+	}
+
+	if v.Disk < 0 {
+		return errors.New("disk can't be negative")
+	}
+
 	// FIXME(nmg)
 	if len(v.Constraints) != 0 {
 		for _, cons := range v.Constraints {


### PR DESCRIPTION
修复：资源数值不能为负，和相关集成测试
FIX http://jira.dataman-inc.com/browse/SGC2-92