### PR TITLE
hijack json.Marshaler & json.Unmarshaler to make fit with int type

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -342,6 +342,8 @@ Content-Type: application/json
             "proxy":{
                 "enabled":false,
                 "alias":""
+				"listen": 99,
+				"sticky": false
             }
         }
     ],
@@ -464,6 +466,8 @@ Example request:
   "proxy": {
             "enabled": false,
             "alias": ""
+			"listen": 99,
+			"sticky": false
   },
   "update": {
       "delay": 5,

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -68,7 +68,7 @@ Request:
 	  "proxy": {
 		"enabled": true,
 		"alias": "g.cn",
-		"listen": ":99",
+		"listen": 99,
 		"sticky": false
 	  }
     },


### PR DESCRIPTION
 - proxy.Listen 对外呈现为 int 型，内部 string 类型不变

通过 Hijack  `json.Marshaler`  `json.Unmarshaler` 实现