### PR TITLE
make swan follower forwarding all requests to swan master

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -84,11 +84,7 @@ func (s *Server) makeHTTPHandler(handler HandlerFunc) http.HandlerFunc {
 		s.enableCORS(w)
 
 		if s.cfg.Listen != s.GetLeader() {
-			if r.Method != "GET" {
-				s.forwardRequest(w, r)
-				return
-			}
-			handler(w, r)
+			s.forwardRequest(w, r)
 			return
 		}
 


### PR DESCRIPTION
related to #860 
调整：swan follower 转发所有请求到 swan master，包括GET请求
因为swan agent 只连 swan master，所有节点上汇聚的 流量/dns/proxy 信息只在swan  master 上有