### PR TITLE
parameter to setup advertise address for swan manager

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -16,8 +16,8 @@ import (
 )
 
 type Config struct {
-	Listen   string
-	LogLevel string
+	Advertise string
+	LogLevel  string
 }
 
 type Server struct {
@@ -83,7 +83,7 @@ func (s *Server) makeHTTPHandler(handler HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		s.enableCORS(w)
 
-		if s.cfg.Listen != s.GetLeader() {
+		if s.cfg.Advertise != s.GetLeader() {
 			s.forwardRequest(w, r)
 			return
 		}

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestNewServer(t *testing.T) {
 	fakeCfg := &Config{
-		Listen:   "hello",
-		LogLevel: "debug",
+		Advertise: "hello",
+		LogLevel:  "debug",
 	}
 	type args struct {
 		cfg    *Config

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -13,6 +13,15 @@ func FlagListenAddr() cli.Flag {
 	}
 }
 
+func FlagAdvertiseAddr() cli.Flag {
+	return cli.StringFlag{
+		Name:   "advertise",
+		Usage:  "http advertise address",
+		EnvVar: "SWAN_ADVERTISE_ADDR",
+		Value:  "",
+	}
+}
+
 func FlagStoreType() cli.Flag {
 	return cli.StringFlag{
 		Name:   "store-type",

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -19,6 +19,7 @@ func ManagerCmd() cli.Command {
 
 	cmd.Flags = []cli.Flag{
 		FlagListenAddr(),
+		FlagAdvertiseAddr(),
 		FlagMesosURL(),
 		FlagStoreType(),
 		FlagZKURL(),

--- a/config/manager.go
+++ b/config/manager.go
@@ -12,6 +12,7 @@ import (
 type ManagerConfig struct {
 	LogLevel   string `json:"logLevel"`
 	Listen     string `json:"listenAddr"`
+	Advertise  string `json:"advertise_addr"`
 	EnableCORS bool
 
 	MesosURL *url.URL `json:"mesosURL"` // mesos zk url
@@ -58,6 +59,12 @@ func NewManagerConfig(c *cli.Context) (*ManagerConfig, error) {
 
 	if c.String("listen") != "" {
 		cfg.Listen = c.String("listen")
+	}
+
+	if c.String("advertise") != "" {
+		cfg.Advertise = c.String("advertise")
+	} else {
+		cfg.Advertise = cfg.Listen
 	}
 
 	if c.String("log-level") != "" {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -88,12 +88,10 @@ func New(cfg *config.ManagerConfig) (*Manager, error) {
 
 	// api server
 	srvcfg := api.Config{
-		Listen:   cfg.Listen,
-		LogLevel: cfg.LogLevel,
+		Advertise: cfg.Advertise,
+		LogLevel:  cfg.LogLevel,
 	}
 	srv := api.NewServer(&srvcfg, hl, sched, db)
-	// router := api.NewRouter(sched, db)
-	// srv.InstallRouter(router)
 
 	// final
 	return &Manager{

--- a/manager/zk_HA.go
+++ b/manager/zk_HA.go
@@ -53,7 +53,7 @@ func connect(addrs []string) (*zk.Conn, error) {
 
 func (m *Manager) setLeader(path string) {
 	p := filepath.Join(m.electRootPath, path)
-	_, err := m.ZKClient.Set(p, []byte(m.cfg.Listen), -1)
+	_, err := m.ZKClient.Set(p, []byte(m.cfg.Advertise), -1)
 	if err != nil {
 		log.Infof("Update leader address error %s", err.Error())
 	}
@@ -96,7 +96,7 @@ func (m *Manager) elect() (string, error) {
 	}
 	if leader {
 		log.Info("Electing leader success.")
-		m.leader = m.cfg.Listen
+		m.leader = m.cfg.Advertise
 		m.setLeader(p)
 		m.leadershipChangeCh <- LeadershipLeader
 


### PR DESCRIPTION
manager 新增参数:  `--advertise`  `SWAN_ADVERTISE_ADDR`  
说明：用来设定manager的对外访问地址，不设置则默认和 `--listen` `SWAN_LISTEN_ADDR` 一致
格式：`host:port`