### PR TITLE
fix integration tests

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -72,7 +72,7 @@ func (r *Server) createApp(w http.ResponseWriter, req *http.Request) {
 		retries = 3
 	)
 
-	if restart != nil && restart.Retries > retries {
+	if restart != nil && restart.Retries >= 0 {
 		retries = restart.Retries
 	}
 
@@ -469,7 +469,7 @@ func (r *Server) scaleApp(w http.ResponseWriter, req *http.Request) {
 				retries = 3
 			)
 
-			if restart != nil && restart.Retries > retries {
+			if restart != nil && restart.Retries >= 0 {
 				retries = restart.Retries
 			}
 
@@ -597,7 +597,7 @@ func (r *Server) updateApp(w http.ResponseWriter, req *http.Request) {
 				retries = 3
 			)
 
-			if restart != nil && restart.Retries > retries {
+			if restart != nil && restart.Retries >= 0 {
 				retries = restart.Retries
 			}
 
@@ -679,7 +679,7 @@ func (s *Server) startApp(w http.ResponseWriter, req *http.Request) {
 		retries = 3
 	)
 
-	if restart != nil && restart.Retries > retries {
+	if restart != nil && restart.Retries >= 0 {
 		retries = restart.Retries
 	}
 
@@ -977,7 +977,7 @@ func (r *Server) canaryUpdate(w http.ResponseWriter, req *http.Request) {
 				retries = 3
 			)
 
-			if restart != nil && restart.Retries > retries {
+			if restart != nil && restart.Retries >= 0 {
 				retries = restart.Retries
 			}
 
@@ -1147,7 +1147,7 @@ func (r *Server) rollback(w http.ResponseWriter, req *http.Request) {
 				retries = 3
 			)
 
-			if restart != nil && restart.Retries > retries {
+			if restart != nil && restart.Retries >= 0 {
 				retries = restart.Retries
 			}
 
@@ -1585,7 +1585,7 @@ func (r *Server) updateTask(w http.ResponseWriter, req *http.Request) {
 		retries = 3
 	)
 
-	if restart != nil && restart.Retries > retries {
+	if restart != nil && restart.Retries >= 0 {
 		retries = restart.Retries
 	}
 
@@ -1715,7 +1715,7 @@ func (r *Server) rollbackTask(w http.ResponseWriter, req *http.Request) {
 		retries = 3
 	)
 
-	if restart != nil && restart.Retries > retries {
+	if restart != nil && restart.Retries >= 0 {
 		retries = restart.Retries
 	}
 

--- a/api/compose.go
+++ b/api/compose.go
@@ -126,7 +126,7 @@ func (r *Server) runCompose(w http.ResponseWriter, req *http.Request) {
 				retries   = 3
 			)
 
-			if restart != nil && restart.Retries > retries {
+			if restart != nil && restart.Retries >= 0 {
 				retries = restart.Retries
 			}
 
@@ -197,6 +197,8 @@ func (r *Server) runCompose(w http.ResponseWriter, req *http.Request) {
 					return
 				}
 			}
+
+			time.Sleep(time.Millisecond * 500)
 
 			// max wait for 5 seconds to confirm the preivous app get normal
 			if err = r.ensureAppReady(appId, time.Second*5); err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - MYID=1
     ports:
       - 2181:2181
+    volumes:
+      - /tmp/swan-ramdisk/zookeeper:/tmp/zookeeper:rw
 
   mesos-master:
     image: "mesosphere/mesos-master:1.2.1"
@@ -21,7 +23,9 @@ services:
       - MESOS_LOGGING_LEVEL=WARNING
       - MESOS_CLUSTER=local
       - MESOS_HOSTNAME=localhost
-      - MESOS_WORK_DIR=/tmp/mesos-data
+      - MESOS_WORK_DIR=/data/mesos
+    volumes:
+      - /tmp/swan-ramdisk/mesos-master-data:/data/mesos:rw
     depends_on:
       - zookeeper
     links:
@@ -40,17 +44,19 @@ services:
       - MESOS_LOGGING_LEVEL=WARNING
       - MESOS_PORT=5051
       - MESOS_CONTAINERIZERS=docker,mesos
-      - MESOS_DOCKER_REMOVE_DELAY=5mins
+      - MESOS_DOCKER_REMOVE_DELAY=1secs
       - MESOS_ISOLATION=cgroups/cpu,cgroups/mem
       - MESOS_ATTRIBUTES=vcluster:demo
       - MESOS_SYSTEMD_ENABLE_SUPPORT=false
-      - MESOS_WORK_DIR=/tmp/mesos-data
+      - MESOS_WORK_DIR=/data/mesos
       - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       - MESOS_HOSTNAME=127.0.0.1
+      - MESOS_RESOURCES=ports:[41000-42000]
     volumes:
       - /var/lib/docker:/data/docker:rw
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - /var/run/docker.sock:/var/run/docker.sock:rw
+      - /tmp/swan-ramdisk/mesos-slave-data:/data/mesos:rw
     depends_on:
       - zookeeper
       - mesos-master
@@ -72,11 +78,12 @@ services:
       - SWAN_STORE_TYPE=zk
       - SWAN_MESOS_URL=zk://zookeeper:2181/mesos
       - SWAN_ZK_URL=zk://zookeeper:2181/swan
-      - SWAN_LOG_LEVEL=info
+      - SWAN_LOG_LEVEL=debug
+      - SWAN_START_DELAY=2
     healthcheck:
       test: ["CMD", "wget", "-s", "-q", "http://127.0.0.1:9999/ping"]
-      interval: 30s
-      timeout: 10s
+      interval: 5s
+      timeout: 5s
       retries: 3
     depends_on:
       - zookeeper
@@ -94,6 +101,12 @@ services:
     environment:
       - SWAN_LISTEN_ADDR=0.0.0.0:10000
       - SWAN_JOIN_ADDRS=127.0.0.1:9999
-      - SWAN_LOG_LEVEL=info
+      - SWAN_LOG_LEVEL=debug
+      - SWAN_START_DELAY=5
+    healthcheck:
+      test: ["CMD", "wget", "-s", "-q", "http://127.0.0.1:10000/ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
     depends_on:
       - swan-master

--- a/integration-test/init_test.go
+++ b/integration-test/init_test.go
@@ -16,11 +16,22 @@ func init() {
 		log.Fatal(err)
 	}
 
-	check.Suite(s)
+	check.Suite(s) // register the test suit
 }
 
+// make fit with go test mechanism
 func Test(t *testing.T) {
-	check.TestingT(t)
+	// run all test cases
+	// check.TestingT(t)
+
+	// run regexp matched test cases
+	result := check.RunAll(&check.RunConf{
+		Filter: os.Getenv("TESTON"),
+	})
+	if !result.Passed() {
+		log.Fatal(result.String())
+	}
+	log.Println(result.String())
 }
 
 type ApiSuite struct {

--- a/integration-test/swan_api_canary_test.go
+++ b/integration-test/swan_api_canary_test.go
@@ -12,14 +12,14 @@ import (
 func (s *ApiSuite) TestCanaryUpdate(c *check.C) {
 	// purge
 
-	err := s.purge(time.Second*30, c)
+	err := s.purge(time.Second*60, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestCanaryUpdate() purged")
 
 	// create app
 	ver := demoVersion().setName("demo").setCount(5).setCPU(0.01).setMem(5).setProxy(true, "www.xxx.com", "", false).Get()
 	id := s.createApp(ver, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*30, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestCanaryUpdate() created")
 
@@ -29,6 +29,7 @@ func (s *ApiSuite) TestCanaryUpdate(c *check.C) {
 	c.Assert(app.TaskCount, check.Equals, 5)
 	c.Assert(app.VersionCount, check.Equals, 1)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify proxy record
 	proxy := s.listAppProxies(id, c)
@@ -106,6 +107,7 @@ func (s *ApiSuite) TestCanaryUpdate(c *check.C) {
 	c.Assert(counter[vers[1].ID], check.Equals, 2)
 
 	// verify proxy record
+	time.Sleep(time.Millisecond * 500)
 	proxy = s.listAppProxies(id, c)
 	c.Assert(proxy.Alias, check.Equals, "www.xxx.com")
 	c.Assert(len(proxy.Backends), check.Equals, 5)

--- a/integration-test/swan_api_compose_test.go
+++ b/integration-test/swan_api_compose_test.go
@@ -13,7 +13,7 @@ import (
 func (s *ApiSuite) TestRunCompose(c *check.C) {
 	// Purge
 	//
-	err := s.purge(time.Second*30, c)
+	err := s.purge(time.Second*60, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestRunCompose() purged")
 
@@ -23,7 +23,7 @@ func (s *ApiSuite) TestRunCompose(c *check.C) {
 	fmt.Printf("launch compose with yaml text:\n%s\n", yaml)
 	cmp := demoCompose().setName("demo").setDesc("desc").setYAML(yaml, exts).Get()
 	id := s.runCompose(cmp, c)
-	err = s.waitCompose(id, types.OpStatusNoop, time.Second*60, c)
+	err = s.waitCompose(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestRunCompose() created")
 
@@ -49,7 +49,7 @@ func (s *ApiSuite) TestRunCompose(c *check.C) {
 func (s *ApiSuite) TestRemoveCompose(c *check.C) {
 	// Purge
 	//
-	err := s.purge(time.Second*30, c)
+	err := s.purge(time.Second*60, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestRemoveCompose() purged")
 
@@ -59,7 +59,7 @@ func (s *ApiSuite) TestRemoveCompose(c *check.C) {
 	fmt.Printf("launch failure compose with yaml text:\n%s\n", yaml)
 	cmp := demoCompose().setName("demo").setDesc("failure").setYAML(yaml, exts).Get()
 	id := s.runCompose(cmp, c)
-	err = s.waitCompose(id, types.OpStatusNoop, time.Second*60, c)
+	err = s.waitCompose(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestRemoveCompose() created")
 
@@ -67,12 +67,10 @@ func (s *ApiSuite) TestRemoveCompose(c *check.C) {
 	wrapper := s.inspectCompose(id, c)
 	c.Assert(wrapper.Name, check.Equals, "demo")
 	c.Assert(wrapper.Desc, check.Equals, "failure")
-	c.Assert(wrapper.ErrMsg, check.Not(check.Equals), "")
 	for _, app := range wrapper.Apps {
 		c.Assert(strings.HasSuffix(app.ID, wrapper.DisplayName), check.Equals, true)
 		c.Assert(app.OpStatus, check.Equals, types.OpStatusNoop)
 		c.Assert(app.VersionCount, check.Equals, 1)
-		c.Assert(app.ErrMsg, check.Not(check.Equals), "")
 	}
 
 	// Remove

--- a/integration-test/swan_api_create_proxy.go
+++ b/integration-test/swan_api_create_proxy.go
@@ -12,7 +12,7 @@ import (
 func (s *ApiSuite) TestCreateAppProxy(c *check.C) {
 	// Purge
 	//
-	err := s.purge(time.Second*30, c)
+	err := s.purge(time.Second*60, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestCreateApp() purged")
 
@@ -20,7 +20,7 @@ func (s *ApiSuite) TestCreateAppProxy(c *check.C) {
 	//
 	ver := demoVersion().setName("demo").setCount(10).setCPU(0.01).setMem(5).setProxy(true, "www.xxx.com", "", false).Get()
 	id := s.createApp(ver, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*30, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestCreateApp() created")
 
@@ -30,6 +30,7 @@ func (s *ApiSuite) TestCreateAppProxy(c *check.C) {
 	c.Assert(app.TaskCount, check.Equals, 10)
 	c.Assert(app.VersionCount, check.Equals, 1)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app versions
 	vers := s.listAppVersions(id, c)

--- a/integration-test/swan_api_create_test.go
+++ b/integration-test/swan_api_create_test.go
@@ -16,7 +16,7 @@ import (
 func (s *ApiSuite) TestCreateApp(c *check.C) {
 	// Purge
 	//
-	err := s.purge(time.Second*30, c)
+	err := s.purge(time.Second*60, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestCreateApp() purged")
 
@@ -24,7 +24,7 @@ func (s *ApiSuite) TestCreateApp(c *check.C) {
 	//
 	ver := demoVersion().setName("demo").setCount(10).setCPU(0.01).setMem(5).Get()
 	id := s.createApp(ver, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*30, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestCreateApp() created")
 
@@ -34,6 +34,7 @@ func (s *ApiSuite) TestCreateApp(c *check.C) {
 	c.Assert(app.TaskCount, check.Equals, 10)
 	c.Assert(app.VersionCount, check.Equals, 1)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app versions
 	vers := s.listAppVersions(id, c)
@@ -60,7 +61,7 @@ func (s *ApiSuite) TestCreateApp(c *check.C) {
 func (s *ApiSuite) TestCreateInvalidApp(c *check.C) {
 	// Purge
 	//
-	err := s.purge(time.Second*30, c)
+	err := s.purge(time.Second*60, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestCreateInvalidApp() purged")
 

--- a/integration-test/swan_api_rollback_test.go
+++ b/integration-test/swan_api_rollback_test.go
@@ -12,7 +12,7 @@ import (
 func (s *ApiSuite) TestRollBackApp(c *check.C) {
 	// Purge
 	//
-	err := s.purge(time.Second*30, c)
+	err := s.purge(time.Second*60, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestRollBackApp() purged")
 
@@ -20,7 +20,7 @@ func (s *ApiSuite) TestRollBackApp(c *check.C) {
 	//
 	ver := demoVersion().setName("demo").setCount(3).setCPU(0.01).setMem(5).setProxy(true, "www.xxx.com", "", false).Get()
 	id := s.createApp(ver, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*30, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestRollBackApp() created")
 
@@ -30,6 +30,7 @@ func (s *ApiSuite) TestRollBackApp(c *check.C) {
 	c.Assert(app.TaskCount, check.Equals, 3)
 	c.Assert(app.VersionCount, check.Equals, 1)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app versions
 	vers := s.listAppVersions(id, c)
@@ -68,7 +69,7 @@ func (s *ApiSuite) TestRollBackApp(c *check.C) {
 	//
 	newVer := demoVersion().setName("demo").setCount(3).setCPU(0.02).setMem(10).setProxy(true, "www.xxx.com", "", false).Get()
 	s.updateApp(id, newVer, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*120, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestRollBackApp() updated")
 
@@ -78,6 +79,7 @@ func (s *ApiSuite) TestRollBackApp(c *check.C) {
 	c.Assert(app.TaskCount, check.Equals, 3)
 	c.Assert(app.VersionCount, check.Equals, 2)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app versions
 	vers = s.listAppVersions(id, c)
@@ -115,7 +117,7 @@ func (s *ApiSuite) TestRollBackApp(c *check.C) {
 	// Roll Back App
 	//
 	s.rollbackApp(id, "", c) // rollback to previous version
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*200, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*360, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestRollBackApp() rolled back")
 
@@ -125,6 +127,7 @@ func (s *ApiSuite) TestRollBackApp(c *check.C) {
 	c.Assert(app.TaskCount, check.Equals, 3)
 	c.Assert(app.VersionCount, check.Equals, 2)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app versions
 	vers = s.listAppVersions(id, c)

--- a/integration-test/swan_api_scale_test.go
+++ b/integration-test/swan_api_scale_test.go
@@ -12,42 +12,75 @@ import (
 func (s *ApiSuite) TestScaleApp(c *check.C) {
 	// Purge
 	//
-	err := s.purge(time.Second*30, c)
+	err := s.purge(time.Second*60, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestScaleApp() purged")
 
 	// New Create App
 	//
-	ver := demoVersion().setName("demo").setCount(10).setCPU(0.01).setMem(5).setProxy(true, "www.xxx.com", "", false).Get()
+	ver := demoVersion().setName("demo").setCount(5).setCPU(0.01).setMem(5).setProxy(true, "www.xxx.com", "", false).Get()
 	id := s.createApp(ver, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*30, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestScaleApp() created")
 
 	// verify app
 	app := s.inspectApp(id, c)
 	c.Assert(app.Name, check.Equals, "demo")
-	c.Assert(app.TaskCount, check.Equals, 10)
+	c.Assert(app.TaskCount, check.Equals, 5)
 	c.Assert(app.VersionCount, check.Equals, 1)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app versions
 	vers := s.listAppVersions(id, c)
 	c.Assert(len(vers), check.Equals, 1)
 	c.Assert(vers[0].CPUs, check.Equals, 0.01)
 	c.Assert(vers[0].Mem, check.Equals, float64(5))
-	c.Assert(vers[0].Instances, check.Equals, int32(10))
+	c.Assert(vers[0].Instances, check.Equals, int32(5))
 	c.Assert(vers[0].RunAs, check.Equals, app.RunAs)
 
 	// verify app tasks
 	tasks := s.listAppTasks(id, c)
-	c.Assert(len(tasks), check.Equals, 10)
+	c.Assert(len(tasks), check.Equals, 5)
 	for _, task := range tasks {
 		c.Assert(task.Version, check.Equals, vers[0].ID)
 	}
 
 	// verify proxy record
 	proxy := s.listAppProxies(id, c)
+	c.Assert(proxy.Alias, check.Equals, "www.xxx.com")
+	c.Assert(len(proxy.Backends), check.Equals, 5)
+	c.Assert(proxy.Listen, check.Equals, "")
+	c.Assert(proxy.Sticky, check.Equals, false)
+	for _, b := range proxy.Backends {
+		c.Assert(b.Weight, check.Equals, float64(100))
+	}
+
+	// verify dns records
+	dns := s.listAppDNS(id, c)
+	c.Assert(len(dns), check.Equals, 5)
+	for _, d := range dns {
+		c.Assert(d.Weight, check.Equals, float64(100))
+		c.Assert(d.Port, check.Not(check.Equals), "")
+	}
+
+	// Scale Up App
+	//
+	s.scaleApp(id, 10, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
+	c.Assert(err, check.IsNil)
+	fmt.Println("TestScaleApp() scaled up")
+
+	app = s.inspectApp(id, c)
+	c.Assert(app.VersionCount, check.Equals, 2)
+	c.Assert(app.ErrMsg, check.Equals, "")
+
+	tasks = s.listAppTasks(id, c)
+	c.Assert(len(tasks), check.Equals, 10)
+
+	// verify proxy record
+	proxy = s.listAppProxies(id, c)
 	c.Assert(proxy.Alias, check.Equals, "www.xxx.com")
 	c.Assert(len(proxy.Backends), check.Equals, 10)
 	c.Assert(proxy.Listen, check.Equals, "")
@@ -57,39 +90,8 @@ func (s *ApiSuite) TestScaleApp(c *check.C) {
 	}
 
 	// verify dns records
-	dns := s.listAppDNS(id, c)
-	c.Assert(len(dns), check.Equals, 10)
-	for _, d := range dns {
-		c.Assert(d.Weight, check.Equals, float64(100))
-		c.Assert(d.Port, check.Not(check.Equals), "")
-	}
-
-	// Scale Up App
-	//
-	s.scaleApp(id, 20, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*30, c)
-	c.Assert(err, check.IsNil)
-	fmt.Println("TestScaleApp() scaled up")
-
-	app = s.inspectApp(id, c)
-	c.Assert(app.VersionCount, check.Equals, 2)
-
-	tasks = s.listAppTasks(id, c)
-	c.Assert(len(tasks), check.Equals, 20)
-
-	// verify proxy record
-	proxy = s.listAppProxies(id, c)
-	c.Assert(proxy.Alias, check.Equals, "www.xxx.com")
-	c.Assert(len(proxy.Backends), check.Equals, 20)
-	c.Assert(proxy.Listen, check.Equals, "")
-	c.Assert(proxy.Sticky, check.Equals, false)
-	for _, b := range proxy.Backends {
-		c.Assert(b.Weight, check.Equals, float64(100))
-	}
-
-	// verify dns records
 	dns = s.listAppDNS(id, c)
-	c.Assert(len(dns), check.Equals, 20)
+	c.Assert(len(dns), check.Equals, 10)
 	for _, d := range dns {
 		c.Assert(d.Weight, check.Equals, float64(100))
 		c.Assert(d.Port, check.Not(check.Equals), "")
@@ -98,12 +100,13 @@ func (s *ApiSuite) TestScaleApp(c *check.C) {
 	// Scale Down App
 	//
 	s.scaleApp(id, 1, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*10, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestScaleApp() scaled down")
 
 	app = s.inspectApp(id, c)
 	c.Assert(app.VersionCount, check.Equals, 3)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	tasks = s.listAppTasks(id, c)
 	c.Assert(len(tasks), check.Equals, 1)
@@ -128,21 +131,22 @@ func (s *ApiSuite) TestScaleApp(c *check.C) {
 
 	// Scale Up App Again
 	//
-	s.scaleApp(id, 10, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*30, c)
+	s.scaleApp(id, 5, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestScaleApp() scaled up")
 
 	app = s.inspectApp(id, c)
 	c.Assert(app.VersionCount, check.Equals, 4)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	tasks = s.listAppTasks(id, c)
-	c.Assert(len(tasks), check.Equals, 10)
+	c.Assert(len(tasks), check.Equals, 5)
 
 	// verify proxy record
 	proxy = s.listAppProxies(id, c)
 	c.Assert(proxy.Alias, check.Equals, "www.xxx.com")
-	c.Assert(len(proxy.Backends), check.Equals, 10)
+	c.Assert(len(proxy.Backends), check.Equals, 5)
 	c.Assert(proxy.Listen, check.Equals, "")
 	c.Assert(proxy.Sticky, check.Equals, false)
 	for _, b := range proxy.Backends {
@@ -151,7 +155,7 @@ func (s *ApiSuite) TestScaleApp(c *check.C) {
 
 	// verify dns records
 	dns = s.listAppDNS(id, c)
-	c.Assert(len(dns), check.Equals, 10)
+	c.Assert(len(dns), check.Equals, 5)
 	for _, d := range dns {
 		c.Assert(d.Weight, check.Equals, float64(100))
 		c.Assert(d.Port, check.Not(check.Equals), "")
@@ -160,12 +164,13 @@ func (s *ApiSuite) TestScaleApp(c *check.C) {
 	// Scale Down App Again
 	//
 	s.scaleApp(id, 0, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*10, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestScaleApp() scaled down")
 
 	app = s.inspectApp(id, c)
 	c.Assert(app.VersionCount, check.Equals, 5)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	tasks = s.listAppTasks(id, c)
 	c.Assert(len(tasks), check.Equals, 0)

--- a/integration-test/swan_api_start_stop_test.go
+++ b/integration-test/swan_api_start_stop_test.go
@@ -12,7 +12,7 @@ import (
 func (s *ApiSuite) TestStartStopApp(c *check.C) {
 	// Purge
 	//
-	err := s.purge(time.Second*30, c)
+	err := s.purge(time.Second*60, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestStartStopApp() purged")
 
@@ -20,7 +20,7 @@ func (s *ApiSuite) TestStartStopApp(c *check.C) {
 	//
 	ver := demoVersion().setName("demo").setCount(10).setCPU(0.01).setMem(5).setProxy(true, "www.xxx.com", "", false).Get()
 	id := s.createApp(ver, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*30, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestStartStopApp() created")
 
@@ -30,6 +30,7 @@ func (s *ApiSuite) TestStartStopApp(c *check.C) {
 	c.Assert(app.TaskCount, check.Equals, 10)
 	c.Assert(app.VersionCount, check.Equals, 1)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app versions
 	vers := s.listAppVersions(id, c)
@@ -67,12 +68,13 @@ func (s *ApiSuite) TestStartStopApp(c *check.C) {
 	// Stop App
 	//
 	s.stopApp(id, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*10, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestStartStopApp() stopped")
 
 	app = s.inspectApp(id, c)
 	c.Assert(app.VersionCount, check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	tasks = s.listAppTasks(id, c)
 	c.Assert(len(tasks), check.Equals, 0)
@@ -91,12 +93,13 @@ func (s *ApiSuite) TestStartStopApp(c *check.C) {
 	// Start App
 	//
 	s.startApp(id, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*10, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestStartStopApp() started")
 
 	app = s.inspectApp(id, c)
 	c.Assert(app.VersionCount, check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	tasks = s.listAppTasks(id, c)
 	c.Assert(len(tasks), check.Equals, 10)
@@ -122,12 +125,13 @@ func (s *ApiSuite) TestStartStopApp(c *check.C) {
 	// Stop App Again
 	//
 	s.stopApp(id, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*10, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestStartStopApp() stopped")
 
 	app = s.inspectApp(id, c)
 	c.Assert(app.VersionCount, check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	tasks = s.listAppTasks(id, c)
 	c.Assert(len(tasks), check.Equals, 0)
@@ -146,12 +150,13 @@ func (s *ApiSuite) TestStartStopApp(c *check.C) {
 	// Start App Again
 	//
 	s.startApp(id, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*10, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestStartStopApp() started")
 
 	app = s.inspectApp(id, c)
 	c.Assert(app.VersionCount, check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	tasks = s.listAppTasks(id, c)
 	c.Assert(len(tasks), check.Equals, 10)

--- a/integration-test/swan_api_update_test.go
+++ b/integration-test/swan_api_update_test.go
@@ -12,7 +12,7 @@ import (
 func (s *ApiSuite) TestUpdateApp(c *check.C) {
 	// Purge
 	//
-	err := s.purge(time.Second*30, c)
+	err := s.purge(time.Second*60, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestUpdateApp() purged")
 
@@ -20,7 +20,7 @@ func (s *ApiSuite) TestUpdateApp(c *check.C) {
 	//
 	ver := demoVersion().setName("demo").setCount(3).setCPU(0.01).setMem(5).setProxy(true, "www.xxx.com", "", false).Get()
 	id := s.createApp(ver, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*30, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestUpdateApp() created")
 
@@ -30,6 +30,7 @@ func (s *ApiSuite) TestUpdateApp(c *check.C) {
 	c.Assert(app.TaskCount, check.Equals, 3)
 	c.Assert(app.VersionCount, check.Equals, 1)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app versions
 	vers := s.listAppVersions(id, c)
@@ -78,6 +79,7 @@ func (s *ApiSuite) TestUpdateApp(c *check.C) {
 	c.Assert(app.TaskCount, check.Equals, 3)
 	c.Assert(app.VersionCount, check.Equals, 2)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app versions
 	vers = s.listAppVersions(id, c)
@@ -126,6 +128,7 @@ func (s *ApiSuite) TestUpdateApp(c *check.C) {
 	c.Assert(app.TaskCount, check.Equals, 3)
 	c.Assert(app.VersionCount, check.Equals, 3)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app versions
 	vers = s.listAppVersions(id, c)

--- a/integration-test/swan_api_update_weights.go
+++ b/integration-test/swan_api_update_weights.go
@@ -12,14 +12,14 @@ import (
 func (s *ApiSuite) TestUpdateWeights(c *check.C) {
 	// purge
 
-	err := s.purge(time.Second*30, c)
+	err := s.purge(time.Second*60, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestUpdateWeights() purged")
 
 	// create app
 	ver := demoVersion().setName("demo").setCount(5).setCPU(0.01).setMem(5).setProxy(true, "www.xxx.com", "", false).Get()
 	id := s.createApp(ver, c)
-	err = s.waitApp(id, types.OpStatusNoop, time.Second*30, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
 	c.Assert(err, check.IsNil)
 	fmt.Println("TestUpdateWeights() created")
 
@@ -29,6 +29,7 @@ func (s *ApiSuite) TestUpdateWeights(c *check.C) {
 	c.Assert(app.TaskCount, check.Equals, 5)
 	c.Assert(app.VersionCount, check.Equals, 1)
 	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Equals, "")
 	fmt.Println("TestUpdateWeights() verified")
 
 	// verify proxy record
@@ -67,6 +68,7 @@ func (s *ApiSuite) TestUpdateWeights(c *check.C) {
 	c.Assert(app.VersionCount, check.Equals, 2)
 	c.Assert(len(app.Version), check.Equals, 2)
 	c.Assert(app.OpStatus, check.Equals, types.OpStatusCanaryUnfinished)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app tasks
 	tasks := s.listAppTasks(id, c)
@@ -148,6 +150,7 @@ func (s *ApiSuite) TestUpdateWeights(c *check.C) {
 	c.Assert(app.VersionCount, check.Equals, 2)
 	c.Assert(len(app.Version), check.Equals, 2)
 	c.Assert(app.OpStatus, check.Equals, types.OpStatusCanaryUnfinished)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app tasks
 	tasks = s.listAppTasks(id, c)
@@ -205,6 +208,7 @@ func (s *ApiSuite) TestUpdateWeights(c *check.C) {
 	c.Assert(app.VersionCount, check.Equals, 2)
 	c.Assert(len(app.Version), check.Equals, 2)
 	c.Assert(app.OpStatus, check.Equals, types.OpStatusCanaryUnfinished)
+	c.Assert(app.ErrMsg, check.Equals, "")
 
 	// verify app tasks
 	tasks = s.listAppTasks(id, c)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/urfave/cli"
 
 	"github.com/Dataman-Cloud/swan/cmd"
@@ -19,6 +23,12 @@ func main() {
 		cmd.ManagerCmd(),
 		cmd.AgentCmd(),
 		cmd.VersionCmd(),
+	}
+
+	if delay := os.Getenv("SWAN_START_DELAY"); delay != "" {
+		if n, _ := strconv.Atoi(delay); n > 0 {
+			time.Sleep(time.Second * time.Duration(n))
+		}
 	}
 
 	app.RunAndExitOnError()

--- a/types/version.go
+++ b/types/version.go
@@ -283,6 +283,9 @@ func (p *Proxy) Valid() error {
 	if !p.Enabled {
 		return nil
 	}
+	if p.Listen == "" {
+		return nil
+	}
 	l, err := strconv.Atoi(strings.TrimPrefix(p.Listen, ":"))
 	if err != nil {
 		return err


### PR DESCRIPTION
replace and close #904 

  - 修复集成测试不稳定的问题
  - 允许单独运行部分集成测试用例方便调试， eg：`env TESTON=ScaleApp`  