### PR TITLE
fix the mess of launch tasks logic

### DIFF
--- a/integration-test/swan_api_create_test.go
+++ b/integration-test/swan_api_create_test.go
@@ -63,6 +63,58 @@ func (s *ApiSuite) TestCreateApp(c *check.C) {
 	costPrintln("TestCreateApp() removed", startAt)
 }
 
+func (s *ApiSuite) TestCreateNoMatchedAgentsApp(c *check.C) {
+	// Purge
+	//
+	startAt := time.Now()
+	err := s.purge(time.Second*60, c)
+	c.Assert(err, check.IsNil)
+	fmt.Println("TestCreateNoMatchedAgentsApp() purged")
+
+	// New Create App
+	//
+	startAt = time.Now()
+	ver := demoVersion().setName("demo").setCount(10).setCPU(0.01).setMem(5).setConstraint("vcluster", "==", "xxxxx").Get()
+	id := s.createApp(ver, c)
+	err = s.waitApp(id, types.OpStatusNoop, time.Second*180, c)
+	c.Assert(err, check.IsNil)
+	costPrintln("TestCreateNoMatchedAgentsApp() created", startAt)
+
+	// verify app
+	app := s.inspectApp(id, c)
+	c.Assert(app.Name, check.Equals, "demo")
+	c.Assert(app.TaskCount, check.Equals, 10)
+	c.Assert(app.VersionCount, check.Equals, 1)
+	c.Assert(len(app.Version), check.Equals, 1)
+	c.Assert(app.ErrMsg, check.Not(check.Equals), "")
+	match, _ := regexp.MatchString("no satisfied agent", app.ErrMsg)
+	c.Assert(match, check.Equals, true)
+
+	// verify app versions
+	vers := s.listAppVersions(id, c)
+	c.Assert(len(vers), check.Equals, 1)
+	c.Assert(vers[0].CPUs, check.Equals, 0.01)
+	c.Assert(vers[0].Mem, check.Equals, float64(5))
+	c.Assert(vers[0].Instances, check.Equals, int32(10))
+	c.Assert(vers[0].RunAs, check.Equals, app.RunAs)
+
+	// verify app tasks
+	tasks := s.listAppTasks(id, c)
+	c.Assert(len(tasks), check.Equals, 10)
+	for _, task := range tasks {
+		c.Assert(task.Status, check.Equals, "pending")
+	}
+
+	costPrintln("TestCreateNoMatchedAgentsApp() failure stats verified", startAt)
+
+	// Remove
+	//
+	startAt = time.Now()
+	err = s.removeApp(id, time.Second*10, c)
+	c.Assert(err, check.IsNil)
+	costPrintln("TestCreateNoMatchedAgentsApp() removed", startAt)
+}
+
 func (s *ApiSuite) TestCreateInvalidApp(c *check.C) {
 	// Purge
 	//

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -84,6 +84,7 @@ func New(cfg *config.ManagerConfig) (*Manager, error) {
 
 	filters := []mesos.Filter{
 		filter.NewConstraintsFilter(),
+		filter.NewResourceFilter(),
 	}
 	sched.InitFilters(filters)
 

--- a/mesos/filter.go
+++ b/mesos/filter.go
@@ -1,28 +1,25 @@
 package mesos
 
 import (
-	//"github.com/Dataman-Cloud/swan/mesos/filter"
 	"github.com/Dataman-Cloud/swan/types"
 )
 
 type Filter interface {
-	Filter(config *types.TaskConfig, agents []*Agent) []*Agent
+	Filter(config *types.TaskConfig, replicas int, agents []*Agent) ([]*Agent, error)
 }
 
-//func NewFilter() []Filter {
-//	filters := []Filter{
-//		filter.NewResourceFilter(),
-//	}
-//
-//	return filters
-//}
-
-func ApplyFilters(filters []Filter, config *types.TaskConfig, agents []*Agent) []*Agent {
+// the returned agents contains at least one proper agent
+func ApplyFilters(filters []Filter, config *types.TaskConfig, replicas int, agents []*Agent) ([]*Agent, error) {
 	accepted := agents
 
+	var err error
 	for _, filter := range filters {
-		accepted = filter.Filter(config, accepted)
+		accepted, err = filter.Filter(config, replicas, accepted)
+		if err != nil {
+			return nil, err
+		}
+
 	}
 
-	return accepted
+	return accepted, nil
 }

--- a/mesos/filter.go
+++ b/mesos/filter.go
@@ -18,7 +18,6 @@ func ApplyFilters(filters []Filter, config *types.TaskConfig, replicas int, agen
 		if err != nil {
 			return nil, err
 		}
-
 	}
 
 	return accepted, nil

--- a/mesos/filter/constraints.go
+++ b/mesos/filter/constraints.go
@@ -1,8 +1,14 @@
 package filter
 
 import (
+	"errors"
+
 	"github.com/Dataman-Cloud/swan/mesos"
 	"github.com/Dataman-Cloud/swan/types"
+)
+
+var (
+	errNoSatisfiedAgent = errors.New("no satisfied agent")
 )
 
 type constraintsFilter struct{}
@@ -11,10 +17,11 @@ func NewConstraintsFilter() *constraintsFilter {
 	return &constraintsFilter{}
 }
 
-func (f *constraintsFilter) Filter(config *types.TaskConfig, agents []*mesos.Agent) []*mesos.Agent {
-	constraints := config.Constraints
-
-	candidates := make([]*mesos.Agent, 0)
+func (f *constraintsFilter) Filter(config *types.TaskConfig, replicas int, agents []*mesos.Agent) ([]*mesos.Agent, error) {
+	var (
+		constraints = config.Constraints
+		candidates  = make([]*mesos.Agent, 0)
+	)
 
 	for _, agent := range agents {
 		match := true
@@ -31,5 +38,8 @@ func (f *constraintsFilter) Filter(config *types.TaskConfig, agents []*mesos.Age
 		}
 	}
 
-	return candidates
+	if len(candidates) == 0 {
+		return nil, errNoSatisfiedAgent
+	}
+	return candidates, nil
 }

--- a/mesos/filter/resource.go
+++ b/mesos/filter/resource.go
@@ -1,8 +1,14 @@
 package filter
 
 import (
+	"errors"
+
 	"github.com/Dataman-Cloud/swan/mesos"
 	"github.com/Dataman-Cloud/swan/types"
+)
+
+var (
+	errResourceNotEnough = errors.New("resource not enough")
 )
 
 type resourceFilter struct {
@@ -12,19 +18,25 @@ func NewResourceFilter() *resourceFilter {
 	return &resourceFilter{}
 }
 
-func (f *resourceFilter) Filter(config *types.TaskConfig, agents []*mesos.Agent) []*mesos.Agent {
+// multiplicate with replicas to calculate total resource requirments
+func (f *resourceFilter) Filter(config *types.TaskConfig, replicas int, agents []*mesos.Agent) ([]*mesos.Agent, error) {
 	candidates := make([]*mesos.Agent, 0)
 
 	for _, agent := range agents {
-		cpus, mem, disk, ports := agent.Resources()
-
-		if cpus >= config.CPUs &&
-			mem >= config.Mem &&
-			disk >= config.Disk &&
-			len(ports) >= len(config.PortMappings) {
+		var (
+			cpus, mem, disk, ports = agent.Resources()               // avaliable agent resources
+			cpusReq                = config.CPUs * float64(replicas) // total resources requirements ...
+			memReq                 = config.Mem * float64(replicas)
+			diskReq                = config.Disk * float64(replicas)
+			portsReq               = len(config.PortMappings) * replicas // FIXME LATER
+		)
+		if cpus >= cpusReq && mem >= memReq && disk >= diskReq && len(ports) >= portsReq {
 			candidates = append(candidates, agent)
 		}
 	}
 
-	return candidates
+	if len(candidates) == 0 {
+		return nil, errResourceNotEnough
+	}
+	return candidates, nil
 }


### PR DESCRIPTION
#912 #889 

 - 使resource filter真正生效
 - 重新整理LaunchTasks逻辑
 - 处理连接mesos失败的情况，避免goroutine leak，修复这种情况下应用永远pending的bug
 - 集成测试用例：测试没有匹配节点时下发应用
 - 集成测试用例：测试资源超限时下发应用