### PR TITLE
bugfix on ipam subnet removal

### DIFF
--- a/agent/ipam/store.go
+++ b/agent/ipam/store.go
@@ -164,7 +164,9 @@ func (s *kvStore) RemoveSubNet(id string) error {
 		return err
 	}
 
-	return s.kv.DeleteTree(s.normalize(subnet.ID))
+	// to make fit with zk & etcd to ensure the keys removed
+	s.kv.DeleteTree(s.normalize(subnet.ID))
+	return s.kv.Delete(s.normalize(subnet.ID))
 }
 
 // Subnet IPs


### PR DESCRIPTION
 `docker network rm` 后会KVStore中有残留的subnet id，PR修复此问题