### PR TITLE
make the strip length more exactly while manager proxying node api requests

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -165,22 +165,22 @@ func (r *Server) getAgentConfigs(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *Server) redirectAgentDocker(w http.ResponseWriter, req *http.Request) {
-	n := len(`/v1/agents/docker/`) + 39 // FIX LATER
+	n := strings.Index(req.URL.Path, "/docker") + len("/docker")
 	r.redirectAgent(n, w, req)
 }
 
 func (r *Server) redirectAgentProxy(w http.ResponseWriter, req *http.Request) {
-	n := len(`/v1/agents/`) + 39
+	n := strings.Index(req.URL.Path, "/proxy")
 	r.redirectAgent(n, w, req)
 }
 
 func (r *Server) redirectAgentDNS(w http.ResponseWriter, req *http.Request) {
-	n := len(`/v1/agents/`) + 39
+	n := strings.Index(req.URL.Path, "/dns")
 	r.redirectAgent(n, w, req)
 }
 
 func (r *Server) redirectAgentIPAM(w http.ResponseWriter, req *http.Request) {
-	n := len(`/v1/agents/`) + 39
+	n := strings.Index(req.URL.Path, "/ipam")
 	r.redirectAgent(n, w, req)
 }
 


### PR DESCRIPTION
主控转发节点API请求的时候，更精确获取需要截取的请求URL长度。
因为 #921 之后使用 mesos slave id 做 swan agent id， 而 mesos slave id 的长度又不是固定的。