### PR TITLE
skip reconciling on on-going apps & pending tasks to avoid rescheduling

### DIFF
--- a/mesos/scheduler.go
+++ b/mesos/scheduler.go
@@ -590,6 +590,16 @@ func (s *Scheduler) runReconcile() {
 		return
 	}
 
+	// filter only the OpStatusNoop apps
+	var idx int
+	for _, app := range apps {
+		if app.OpStatus == types.OpStatusNoop {
+			apps[idx] = app
+			idx++
+		}
+	}
+	apps = apps[:idx]
+
 	tasks := make([]*types.Task, 0)
 
 	for _, app := range apps {
@@ -600,6 +610,10 @@ func (s *Scheduler) runReconcile() {
 		}
 
 		for _, t := range ts {
+			// skip pending tasks
+			if t.Status == "pending" {
+				continue
+			}
 			tasks = append(tasks, t)
 		}
 	}


### PR DESCRIPTION
`Reconcile` 应该忽略操作中的App和pending状态的Task，以防止重新调度的逻辑和当前操作冲突